### PR TITLE
fix the opposite case of following before connecting

### DIFF
--- a/events.js
+++ b/events.js
@@ -171,9 +171,9 @@ module.exports = function (version) {
     //create a replication for that peer.
 
     for(var id in state.follows) {
-      var seq = clock[id], lseq = state.clock[id] || 0
+      var seq = clock[id] || 0, lseq = state.clock[id] || 0
       //BLOCK: check wether id has blocked this peer
-      if(isShared(state, id, ev.id) && seq !== -1 && seq !== lseq) {
+      if(isShared(state, id, ev.id) && seq !== -1 && seq !== state.clock[id]) {
 
         //if we are already replicating, and this feed is at zero, ask for it anyway,
         //XXX if a feed is at zero, but we are replicating on another peer

--- a/test/index.js
+++ b/test/index.js
@@ -207,6 +207,21 @@ test('replicate a hops=2 peer that my hops=1 friend still doesnt have', function
   t.end()
 })
 
+test('replicate a hops=2 peer that my hops=1 friend still doesnt have (2)', function (t) {
+  var state = events.initialize()
+  state = events.clock(state, {})
+
+  state = events.follow(state, {id: 'alice', value: true})
+  state = events.follow(state, {id: 'bob', value: true})
+
+  state = events.connect(state, {id: 'alice', client: false})
+  state = events.peerClock(state, {id: 'alice', value: {'alice': 0, 'bob': 0}})
+
+  t.ok(state.peers['alice'].replicating['bob'])
+
+  t.end()
+})
+
 test('reply to any clock they send, 1', function (t) {
   var state = {
     clock: { alice: 3, bob: 2, charles: 3 },


### PR DESCRIPTION
1st test :x:, 2nd fix :heavy_check_mark: 

----

The difference here is that `events.follow()` will not update `replicating` if we're not connected to anyone, so we're testing whether things work even if we do `events.follow()` before `events.connect()`, which is the case when `events.peerClock()` is called afterwards. In SSB, that's the case when the secret-stack plugins initialize, then ssb-replication-scheduler uses ssb-friends to do a bunch of `ssb.ebt.request()`, but we're still not connected to anyone.