### PR TITLE
Remove redundant onAppend call

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,6 @@ module.exports = function (opts) {
             if(self.logging) console.error('EBT:err', err)
             self.block(ev.value.author, ev.id, true)
           }
-          else self.onAppend(ev.value)
         })
       }
       for(var k in self.streams)


### PR DESCRIPTION
Context: We were trying to figure out a problem related to blocked messages being sent. See https://github.com/ssbc/ssb-ebt/pull/52 and https://github.com/ssbc/ssb-ebt/pull/55. While debugging those I found this seamingly redundant `onAppend` call.

What happens here is that when we receive a message we add it to our database and then after it is added we call onAppend to tell other peers about the message. While this in a way is correct, one needs to handle this a lot more generally, like if you yourself wrote the message, you have to call onAppend anyway or if something else added the message to the database this is the same issue. So in ssb-ebt we handle this with a [post hook](https://github.com/ssbc/ssb-ebt/blob/b9a7f8b097d41c7f7b33eef9167e517953e06923/index.js#L86). This means that with ssb-ebt driving ebt we end up calling onAppend twice. This is not a problem because onAppend will handle this, it is just wasteful. The main reason for opening this PR is that it also makes it harder to reason about how the system behaves.

After this change it is always the responsibility of the one running EBT to call onAppend when it has a new message.

This change has been tested in ssb-ebt and ssb-replication-scheduler and no issues are found. This also passes all local tests which is in a way a good indicator that maybe this call should not have been here in the first place.

