### PR TITLE
Fix blocking false

### DIFF
--- a/events.js
+++ b/events.js
@@ -370,7 +370,7 @@ module.exports = function (version) {
       //BLOCK: or wether id has blocked this peer
       if (!isShared(state, id, ev.id)) {
         if (!peer.replicating[id])
-          setNotes(peer, id, -1)
+          setNotes(peer, id, -1, false)
         peer.replicating[id] = {tx: false, rx: false, sent: -1, requested: -1}
       }
       else {
@@ -472,20 +472,20 @@ module.exports = function (version) {
     else {
       state.blocks[ev.id] = state.blocks[ev.id] || {}
       state.blocks[ev.id][ev.target] = true
-    }
 
-    //if we blocked this peer, and we are also connected to them.
-    //then stop replicating immediately.
-    if (state.id === ev.id && state.peers[ev.target]) {
-      //end replication immediately.
-      state.peers[ev.target].blocked = ev.value
-    }
+      //if we blocked this peer, and we are also connected to them.
+      //then stop replicating immediately.
+      if (state.id === ev.id && state.peers[ev.target]) {
+        //end replication immediately.
+        state.peers[ev.target].blocked = ev.value
+      }
 
-    for (var id in state.peers) {
-      var peer = state.peers[id]
-      if (!peer.replicating) continue
-      if (id === ev.target && peer.replicating[ev.id])
-        setNotes(peer, ev.id, -1, false)
+      for (var id in state.peers) {
+        var peer = state.peers[id]
+        if (!peer.replicating) continue
+        if (id === ev.target && peer.replicating[ev.id])
+          setNotes(peer, ev.id, -1, false)
+      }
     }
 
     return state

--- a/test/block.js
+++ b/test/block.js
@@ -82,5 +82,24 @@ test("don't send retrived message to blocked peer", function (t) {
   t.end()
 })
 
+test("blocking false on a connected peer does nothing", function (t) {
+  var state = events.initialize('alice')
+  state.clock = {alice: 3, charles: 2}
+  state = events.connect(state, {id: 'charles', ts: 1, client: false})
+  //state = events.peerClock(state, {id: 'charles', value: { charles: 2 }})
+  state = events.peerClock(state, {id: 'charles', value: {'alice': 0, 'charles': 0}})
+
+  state = events.follow(state, {id: 'alice', value: true})
+  state = events.follow(state, {id: 'charles', value: true})
+
+  state = events.notes(state, {id: 'charles', value: {charles: 2}})
+  const existingNote = state.peers['charles'].notes['alice']
+  // this should not change anything
+  state = events.block(state, {id: 'alice', target: 'charles', value: false})
+  t.equal(state.peers['charles'].notes['alice'], existingNote)
+
+  t.end()
+})
+
 
 


### PR DESCRIPTION
First a failing test, then a fix. Context for this bug is this issue: https://github.com/ssbc/ssb-ebt/issues/61. We pair debugged the issue and found that replication scheduler now does a lot of blocking false to ensure that the state is correct. Sadly this is not working properly in EBT and is a bug since blocking was introduced 4 years ago.