### PR TITLE
add standard, do basic lint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+package-lock.json

--- a/events.js
+++ b/events.js
@@ -1,10 +1,9 @@
 'use strict'
 
 module.exports = function (version) {
-
   const { note, getReceive, getReplicate, getSequence } = version
 
-  var exports = {
+  const exports = {
     note,
     getReceive,
     getReplicate,
@@ -12,15 +11,15 @@ module.exports = function (version) {
   }
 
   function isEmpty (o) {
-    for (var k in o) return false
+    for (const k in o) return false
     return true
   }
 
   function isObject (o) {
-    return o && 'object' === typeof o
+    return o && typeof o === 'object'
   }
 
-  function isBlocked(state, id, target) {
+  function isBlocked (state, id, target) {
     return state.blocks[id] && state.blocks[id][target]
   }
 
@@ -28,16 +27,16 @@ module.exports = function (version) {
     return state.follows[id] && !isBlocked(state, id, peerId)
   }
 
-  //check if a feed is already being replicated on another peer from ignoreId
-  function isAlreadyReplicating(state, feedId, ignoreId) {
-    for (var id in state.peers) {
+  // check if a feed is already being replicated on another peer from ignoreId
+  function isAlreadyReplicating (state, feedId, ignoreId) {
+    for (const id in state.peers) {
       if (id !== ignoreId) {
-        var peer = state.peers[id]
+        const peer = state.peers[id]
         if (peer.notes && getReceive(peer.notes[id])) return id
 
         // for replicating the node must have replicated something not just rx
         // this fixed a partial replication bug where a node is unable to send the full log
-        var idHasSent = peer.replicating && peer.replicating[id] && peer.replicating[id].sent != -1
+        const idHasSent = peer.replicating && peer.replicating[id] && peer.replicating[id].sent !== -1
         if (peer.replicating && peer.replicating[feedId] && peer.replicating[feedId].rx && idHasSent) return id
       }
     }
@@ -48,19 +47,19 @@ module.exports = function (version) {
   // if one is -1 and the other is not, use the other
   function fixSeq (local, remote) {
     if (local == null) return remote
-    if (local == -1 || remote == -1) return remote
-    if (remote == 0) return 0
+    if (local === -1 || remote === -1) return remote
+    if (remote === 0) return 0
     if (remote > 0 && local > 0 && remote < local) return remote
     return Math.max(local, remote)
   }
 
-  //check if a feed is available from a peer apart from ignoreId
+  // check if a feed is available from a peer apart from ignoreId
 
-  function isAvailable(state, feedId, ignoreId) {
-    for (var peerId in state.peers) {
-      if (peerId != ignoreId) {
-        var peer = state.peers[peerId]
-        //BLOCK: check wether id has blocked this peer
+  function isAvailable (state, feedId, ignoreId) {
+    for (const peerId in state.peers) {
+      if (peerId !== ignoreId) {
+        const peer = state.peers[peerId]
+        // BLOCK: check wether id has blocked this peer
         if ((peer.clock && peer.clock[feedId] || 0) > (state.clock[feedId] || 0) && isShared(state, feedId, peerId)) {
           return true
         }
@@ -68,25 +67,25 @@ module.exports = function (version) {
     }
   }
 
-  //jump to a particular key in a list, then iterate from there
-  //back around to the key. this is used for switching away from
-  //peers that stall so that you'll rotate through all the peers
-  //not just swich between two different peers.
+  // jump to a particular key in a list, then iterate from there
+  // back around to the key. this is used for switching away from
+  // peers that stall so that you'll rotate through all the peers
+  // not just swich between two different peers.
 
-  function eachFrom(keys, key, iter) {
-    var i = keys.indexOf(key)
+  function eachFrom (keys, key, iter) {
+    const i = keys.indexOf(key)
     if (!~i) return
-    //start at 1 because we want to visit all keys but key.
-    for (var j = 1; j < keys.length; j++)
-      if (iter(keys[(j+i) % keys.length], j))
-        return
+    // start at 1 because we want to visit all keys but key.
+    for (let j = 1; j < keys.length; j++) {
+      if (iter(keys[(j + i) % keys.length], j)) { return }
+    }
   }
 
   function setNotes (peer, feed, seq, rx) {
     peer.notes = peer.notes || {}
     peer.notes[feed] = note(seq, rx)
 
-    var rep = peer.replicating[feed]
+    const rep = peer.replicating[feed]
     if (rep) {
       rep.rx = rx
       rep.requested = seq
@@ -94,21 +93,19 @@ module.exports = function (version) {
   }
 
   // defaults for backwards compatibility
-  exports.getMsgAuthor = function(msg) {
+  exports.getMsgAuthor = function (msg) {
     return msg.author
   }
-  exports.getMsgSequence = function(msg) {
+  exports.getMsgSequence = function (msg) {
     return msg.sequence
   }
 
   exports.initialize = function (id, getMsgAuthor, getMsgSequence) {
-    if (getMsgAuthor)
-      exports.getMsgAuthor = getMsgAuthor
-    if (getMsgSequence)
-      exports.getMsgSequence = getMsgSequence
+    if (getMsgAuthor) { exports.getMsgAuthor = getMsgAuthor }
+    if (getMsgSequence) { exports.getMsgSequence = getMsgSequence }
 
     return {
-      id: id,
+      id,
       clock: null,
       follows: {},
       blocks: {},
@@ -123,8 +120,8 @@ module.exports = function (version) {
   }
 
   exports.connect = function (state, ev) {
-    if (state.peers[ev.id]) throw new Error('already connected to peer:'+ev.id)
-    if (typeof ev.client != 'boolean') throw new Error('connect.client must be boolean')
+    if (state.peers[ev.id]) throw new Error('already connected to peer:' + ev.id)
+    if (typeof ev.client !== 'boolean') throw new Error('connect.client must be boolean')
 
     //  if (isBlocked(state, state.id, ev.id)) return state
 
@@ -135,9 +132,9 @@ module.exports = function (version) {
       msgs: [],
       retrive: [],
       notes: null,
-      //if we are client, wait until we receive notes to send code.
-      //this is a weird way of doing it! shouldn't we just have a bit of state
-      //for wether we have received a vector clock
+      // if we are client, wait until we receive notes to send code.
+      // this is a weird way of doing it! shouldn't we just have a bit of state
+      // for wether we have received a vector clock
       replicating: ev.client ? null : {}
     }
 
@@ -149,36 +146,34 @@ module.exports = function (version) {
     return state
   }
 
-  //this is when the stored peer clock has been loaded from the local database.
-  //note, this must be handled before any messages are received.
+  // this is when the stored peer clock has been loaded from the local database.
+  // note, this must be handled before any messages are received.
   exports.peerClock = function (state, ev) {
-    if (!state.peers[ev.id])
-      throw new Error('peerClock called for:'+ev.id + ' but only connected to:'+ Object.keys(state.peers))
-    var peer = state.peers[ev.id]
-    var clock = peer.clock = ev.value
+    if (!state.peers[ev.id]) { throw new Error('peerClock called for:' + ev.id + ' but only connected to:' + Object.keys(state.peers)) }
+    const peer = state.peers[ev.id]
+    const clock = peer.clock = ev.value
 
-    //client should wait for the server notes, so that stream
-    //can error before a peer sends a massive handshake.
+    // client should wait for the server notes, so that stream
+    // can error before a peer sends a massive handshake.
     if (peer.replicating == null) return state
 
-    //always set an empty clock here, so that if we don't have anything
-    //to send, we still send this empty clock. This only happens on a new connection.
-    //in every other situation, clock is only sent if there is something in it.
+    // always set an empty clock here, so that if we don't have anything
+    // to send, we still send this empty clock. This only happens on a new connection.
+    // in every other situation, clock is only sent if there is something in it.
     peer.notes = peer.notes || {}
 
-    //iterate over following and create replications.
-    //if we want to replicate a peer that has changed since their clock,
-    //create a replication for that peer.
+    // iterate over following and create replications.
+    // if we want to replicate a peer that has changed since their clock,
+    // create a replication for that peer.
 
-    for (var id in state.follows) {
-      var seq = clock[id] || 0, lseq = state.clock[id] || 0
-      //BLOCK: check wether id has blocked this peer
+    for (const id in state.follows) {
+      const seq = clock[id] || 0; const lseq = state.clock[id] || 0
+      // BLOCK: check wether id has blocked this peer
       if (isShared(state, id, ev.id) && seq !== -1 && seq !== state.clock[id]) {
-
-        //if we are already replicating, and this feed is at zero, ask for it anyway,
-        //XXX if a feed is at zero, but we are replicating on another peer
-        //just don't ask for it yet?
-        var replicating = isAlreadyReplicating(state, id, ev.id)// && lseq
+        // if we are already replicating, and this feed is at zero, ask for it anyway,
+        // XXX if a feed is at zero, but we are replicating on another peer
+        // just don't ask for it yet?
+        const replicating = isAlreadyReplicating(state, id, ev.id)// && lseq
         peer.replicating = peer.replicating || {}
         peer.replicating[id] = {
           tx: false,
@@ -193,34 +188,34 @@ module.exports = function (version) {
     return state
   }
 
-  //XXX handle replicating with only one peer.
+  // XXX handle replicating with only one peer.
   exports.follow = function (state, ev) {
-    //set to true once we have asked for this feed from someone.
-    var replicating = false
+    // set to true once we have asked for this feed from someone.
+    let replicating = false
     if (!!state.follows[ev.id] !== ev.value) {
       state.follows[ev.id] = ev.value
-      for (var id in state.peers) {
-        var peer = state.peers[id]
+      for (const id in state.peers) {
+        const peer = state.peers[id]
         if (!peer.clock || !peer.replicating || !isShared(state, ev.id, id)) continue
-        //BLOCK: check wether this feed has has blocked this peer.
-        //..... don't replicate feeds with peers that have blocked them at all?
+        // BLOCK: check wether this feed has has blocked this peer.
+        // ..... don't replicate feeds with peers that have blocked them at all?
 
-        //cases:
+        // cases:
         //  don't have feed
         //  do have feed
         //  peer has feed
         //  peer rejects feed
-        var seq = peer.clock[ev.id] || 0, lseq = state.clock[ev.id] || 0
+        const seq = peer.clock[ev.id] || 0; const lseq = state.clock[ev.id] || 0
         if (seq === -1) {
-          //peer explicitly does not replicate this feed, don't ask for it.
-        }
-        else if (ev.value === false) { //unfollow
+          // peer explicitly does not replicate this feed, don't ask for it.
+        } else if (ev.value === false) { // unfollow
           setNotes(peer, ev.id, -1, false)
-        }
-        else if (ev.value === true && seq !== state.clock[ev.id]) {
+        } else if (ev.value === true && seq !== state.clock[ev.id]) {
           peer.replicating[ev.id] = {
-            rx: true, tx: false,
-            sent: -1, requested: lseq
+            rx: true,
+            tx: false,
+            sent: -1,
+            requested: lseq
           }
           setNotes(peer, ev.id, lseq, !replicating)
           replicating = true
@@ -231,20 +226,20 @@ module.exports = function (version) {
   }
 
   exports.retrive = function (state, msg) {
-    //check if any peer requires this msg
-    for (var id in state.peers) {
-      var peer = state.peers[id]
+    // check if any peer requires this msg
+    for (const id in state.peers) {
+      const peer = state.peers[id]
       if (!peer.replicating) continue
-      //BLOCK: check wether id has blocked this peer
+      // BLOCK: check wether id has blocked this peer
       const author = exports.getMsgAuthor(msg)
       const sequence = exports.getMsgSequence(msg)
-      var rep = peer.replicating[author]
+      const rep = peer.replicating[author]
 
       if (rep && rep.tx && rep.sent === sequence - 1) {
         rep.sent++
         peer.msgs.push(msg)
         if (rep.sent < state.clock[author]) {
-          //use continue, not return because we still need to loop through other peers.
+          // use continue, not return because we still need to loop through other peers.
           if (~peer.retrive.indexOf(author)) continue
           peer.retrive.push(author)
         }
@@ -253,7 +248,7 @@ module.exports = function (version) {
     return state
   }
 
-  function isAhead(seq1, seq2) {
+  function isAhead (seq1, seq2) {
     if (seq2 === -1) return false
     if (seq2 == null) return true
     if (seq1 > seq2) return true
@@ -262,120 +257,114 @@ module.exports = function (version) {
   exports.append = function (state, msg) {
     const author = exports.getMsgAuthor(msg)
     const sequence = exports.getMsgSequence(msg)
-    //check if any peer requires this msg
-    if (state.clock[author] != null && state.clock[author] !== sequence - 1)
-      return state //ignore
+    // check if any peer requires this msg
+    if (state.clock[author] != null && state.clock[author] !== sequence - 1) { return state } // ignore
 
-    var lseq = state.clock[author] = sequence
-    for (var id in state.peers) {
-      var peer = state.peers[id]
+    const lseq = state.clock[author] = sequence
+    for (const id in state.peers) {
+      const peer = state.peers[id]
       if (!peer.clock || !peer.replicating || !isShared(state, author, id)) continue
-      //BLOCK: check wether msg.author has blocked this peer
+      // BLOCK: check wether msg.author has blocked this peer
 
-      var seq = peer.clock[author]
+      const seq = peer.clock[author]
 
-      var rep = peer.replicating[author]
+      const rep = peer.replicating[author]
 
-      if (rep && rep.tx && rep.sent == lseq - 1 && lseq > seq) {
+      if (rep && rep.tx && rep.sent === lseq - 1 && lseq > seq) {
         peer.msgs.push(msg)
         rep.sent++
-      }
-      //if we are ahead of this peer, and not in tx mode, let them know that.
+      } // eslint-disable-line
+      // if we are ahead of this peer, and not in tx mode, let them know that.
       else if (
         isAhead(lseq, seq) &&
           (rep ? !rep.tx && rep.sent != null : state.follows[author])
-      )
-        setNotes(peer, author, sequence, false)
+      ) { setNotes(peer, author, sequence, false) }
     }
 
     return state
   }
 
-  //XXX if we only receive from a single peer,
-  //then we shouldn't really get known messages?
-  //except during the race when we have disabled a peer
-  //but they havn't noticed yet.
+  // XXX if we only receive from a single peer,
+  // then we shouldn't really get known messages?
+  // except during the race when we have disabled a peer
+  // but they havn't noticed yet.
   exports.receive = function (state, ev) {
-    var msg = ev.value
-    //receive a message, validate and append.
-    //if this message is forked, disable this feed
+    const msg = ev.value
+    // receive a message, validate and append.
+    // if this message is forked, disable this feed
 
-    if (!state.peers[ev.id]) throw new Error('lost peer state:'+ev.id)
+    if (!state.peers[ev.id]) throw new Error('lost peer state:' + ev.id)
 
-    //we _know_ that this peer is upto at least this message now.
-    //(but maybe they already told us they where ahead further)
+    // we _know_ that this peer is upto at least this message now.
+    // (but maybe they already told us they where ahead further)
     const author = exports.getMsgAuthor(msg)
     const sequence = exports.getMsgSequence(msg)
-    var peer = state.peers[ev.id]
-    var rep = peer.replicating[author]
+    const peer = state.peers[ev.id]
+    const rep = peer.replicating[author]
 
-    //if we havn't asked for this, ignore it. (this is remote speaking protocol wrong!)
+    // if we havn't asked for this, ignore it. (this is remote speaking protocol wrong!)
     if (!rep) return state
 
     peer.clock[author] = Math.max(peer.clock[author], sequence)
     rep.sent = Math.max(rep.sent, sequence)
 
-    //if this message has already been seen, ignore.
+    // if this message has already been seen, ignore.
     if (state.clock[author] >= sequence) {
       if (rep.rx) {
         setNotes(peer, author, state.clock[author], false)
       }
-      //XXX activate some other peer?
+      // XXX activate some other peer?
       return state
     }
 
-    //remember the time of the last message received
+    // remember the time of the last message received
     state.peers[ev.id].ts = ev.ts
 
-    //FORKS ignore additional messages if we have already found an invalid one.
-    if (isShared(state, author, ev.id))
-      state.receive.push(ev)
-    //Q: possibly update the receiving mode?
+    // FORKS ignore additional messages if we have already found an invalid one.
+    if (isShared(state, author, ev.id)) { state.receive.push(ev) }
+    // Q: possibly update the receiving mode?
 
     return state
   }
 
-  //XXX check if we are already receiving a feed
-  //and if so put this into lazy mode.
+  // XXX check if we are already receiving a feed
+  // and if so put this into lazy mode.
   exports.notes = function (state, ev) {
-    //update replicating modes
-    var clock = ev.value
+    // update replicating modes
+    let clock = ev.value
 
-    //support sending clocks inside a thing with additional properties.
-    //this is to allow room for backwards compatible upgrades.
-    if (isObject(ev.value.clock))
-      clock = ev.value.clock
+    // support sending clocks inside a thing with additional properties.
+    // this is to allow room for backwards compatible upgrades.
+    if (isObject(ev.value.clock)) { clock = ev.value.clock }
 
-    var peer = state.peers[ev.id]
-    if (!peer) throw new Error('lost state of peer:'+ev.id)
+    const peer = state.peers[ev.id]
+    if (!peer) throw new Error('lost state of peer:' + ev.id)
     if (!peer.clock) throw new Error("received notes, but has not set the peer's clock yet")
-    var count = 0
+    let count = 0
 
-    //if we are client, and this is the first notes we receive
+    // if we are client, and this is the first notes we receive
     if (!peer.replicating) {
       peer.replicating = {}
-      state = exports.peerClock(state, {id: ev.id, value: state.peers[ev.id].clock})
+      state = exports.peerClock(state, { id: ev.id, value: state.peers[ev.id].clock })
     }
 
-    for (var id in clock) {
+    for (const id in clock) {
       count++
 
-      var seq = peer.clock[id] = fixSeq(peer.clock[id], getSequence(clock[id]))
-      var tx = getReceive(clock[id]) // is even
-      var isReplicate = getReplicate(clock[id]) // !== -1
+      const seq = peer.clock[id] = fixSeq(peer.clock[id], getSequence(clock[id]))
+      const tx = getReceive(clock[id]) // is even
+      const isReplicate = getReplicate(clock[id]) // !== -1
 
-      var lseq = state.clock[id] || 0
+      const lseq = state.clock[id] || 0
 
-      //check if we are not following this feed.
-      //BLOCK: or wether id has blocked this peer
+      // check if we are not following this feed.
+      // BLOCK: or wether id has blocked this peer
       if (!isShared(state, id, ev.id)) {
-        if (!peer.replicating[id])
-          setNotes(peer, id, -1, false)
-        peer.replicating[id] = {tx: false, rx: false, sent: -1, requested: -1}
-      }
-      else {
-        var rep = peer.replicating[id]
-        var replicating = isAlreadyReplicating(state, id, ev.id)
+        if (!peer.replicating[id]) { setNotes(peer, id, -1, false) }
+        peer.replicating[id] = { tx: false, rx: false, sent: -1, requested: -1 }
+      } else {
+        let rep = peer.replicating[id]
+        const replicating = isAlreadyReplicating(state, id, ev.id)
         if (!rep) {
           rep = peer.replicating[id] = {
             tx: true,
@@ -384,30 +373,29 @@ module.exports = function (version) {
             requested: lseq
           }
           setNotes(peer, id, lseq, lseq < seq && !replicating)
-        }
-        else if (!rep.rx && seq > lseq) {
+        } else if (!rep.rx && seq > lseq) {
           if (!replicating) {
-            peer.ts = ev.ts //remember ts, so we can switch this feed if necessary
+            peer.ts = ev.ts // remember ts, so we can switch this feed if necessary
             setNotes(peer, id, lseq, true)
           } else {
-            //if we are already replicating this via another peer
-            //switch to this peer if it is further ahead.
-            //(todo?: switch if the other peer's timestamp is old?)
-            var _peer = state.peers[replicating]
+            // if we are already replicating this via another peer
+            // switch to this peer if it is further ahead.
+            // (todo?: switch if the other peer's timestamp is old?)
+            const _peer = state.peers[replicating]
             // note: _peer.clock[id] may be undefined, if we have
             // just connected to them and sent our notes but not
             // received theirs.
             if (seq > (_peer.clock[id] || 0)) {
               peer.ts = ev.ts
               setNotes(peer, id, lseq, true)
-              setNotes(_peer, id, lseq, false) //deactivate the previous peer
+              setNotes(_peer, id, lseq, false) // deactivate the previous peer
             }
           }
         }
 
-        //positive seq means "send this to me please"
+        // positive seq means "send this to me please"
         rep.tx = tx
-        //in the case we are already ahead, get ready to send them messages.
+        // in the case we are already ahead, get ready to send them messages.
         rep.sent = seq
         if (lseq > seq) {
           if (tx) peer.retrive.push(id)
@@ -421,19 +409,18 @@ module.exports = function (version) {
   }
 
   exports.timeout = function (state, ev) {
-    var want = {}
+    const want = {}
 
-    for (var peerId in state.peers) {
-      var peer = state.peers[peerId]
-      //check if the peer hasn't received a message recently.
+    for (const peerId in state.peers) {
+      const peer = state.peers[peerId]
+      // check if the peer hasn't received a message recently.
 
-      //if we havn't received a message from this peer recently
+      // if we havn't received a message from this peer recently
       if ((peer.ts || 0) + state.timeout < ev.ts) {
-        //check if they have claimed a higher sequence, but not sent us
-        for (var id in peer.replicating) {
-
-          var rep = peer.replicating[id]
-          //if yes, prepare to switch this feed to that peer
+        // check if they have claimed a higher sequence, but not sent us
+        for (const id in peer.replicating) {
+          const rep = peer.replicating[id]
+          // if yes, prepare to switch this feed to that peer
           if (rep.rx && isAvailable(state, id, peerId)) {
             want[id] = peerId
             setNotes(peer, id, state.clock[id], false)
@@ -442,19 +429,19 @@ module.exports = function (version) {
       }
     }
 
-    var peerIds = Object.keys(state.peers)
-    for (var feedId in want) {
-      var ignoreId = want[feedId]
+    const peerIds = Object.keys(state.peers)
+    for (const feedId in want) {
+      const ignoreId = want[feedId]
       eachFrom(peerIds, ignoreId, function (peerId) {
-        var peer = state.peers[peerId]
-        if (peer.clock && peer.clock[feedId] || 0 > state.clock[feedId] || 0) {
+        const peer = state.peers[peerId]
+        if (peer.clock && peer.clock[feedId] || state.clock[feedId] < 0 || 0) {
           peer.replicating = peer.replicating || {}
           peer.replicating[feedId] = peer.replicating[feedId] || {
             tx: false, rx: true, sent: -1, requested: state.clock[feedId]
           }
           setNotes(peer, feedId, state.clock[feedId], true)
           peer.ts = ev.ts
-          //returning true triggers the end of eachFrom
+          // returning true triggers the end of eachFrom
           return true
         }
       })
@@ -466,25 +453,22 @@ module.exports = function (version) {
   exports.block = function (state, ev) {
     if (!ev.value) {
       if (state.blocks[ev.id]) delete state.blocks[ev.id][ev.target]
-      if (isEmpty(state.blocks[ev.id]))
-        delete state.blocks[ev.id]
-    }
-    else {
+      if (isEmpty(state.blocks[ev.id])) { delete state.blocks[ev.id] }
+    } else {
       state.blocks[ev.id] = state.blocks[ev.id] || {}
       state.blocks[ev.id][ev.target] = true
 
-      //if we blocked this peer, and we are also connected to them.
-      //then stop replicating immediately.
+      // if we blocked this peer, and we are also connected to them.
+      // then stop replicating immediately.
       if (state.id === ev.id && state.peers[ev.target]) {
-        //end replication immediately.
+        // end replication immediately.
         state.peers[ev.target].blocked = ev.value
       }
 
-      for (var id in state.peers) {
-        var peer = state.peers[id]
+      for (const id in state.peers) {
+        const peer = state.peers[id]
         if (!peer.replicating) continue
-        if (id === ev.target && peer.replicating[ev.id])
-          setNotes(peer, ev.id, -1, false)
+        if (id === ev.target && peer.replicating[ev.id]) { setNotes(peer, ev.id, -1, false) }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -11,53 +11,51 @@ module.exports = function (opts) {
   const events = Events(v3)
   const Stream = StreamModule(events)
 
-  var state = events.initialize(opts.id, opts.getMsgAuthor, opts.getMsgSequence)
+  const state = events.initialize(opts.id, opts.getMsgAuthor, opts.getMsgSequence)
   state.timeout = opts.timeout || 3000
   state.clock = {}
 
   if (!opts.isMsg) {
-    opts.isMsg = function(m) {
+    opts.isMsg = function (m) {
       return Number.isInteger(m.sequence) && m.sequence > 0 &&
-        typeof m.author == 'string' && m.content
+        typeof m.author === 'string' && m.content
     }
   }
 
-  var self = {
+  const self = {
     id: opts.id,
     streams: {},
-    state: state,
+    state,
     logging: opts.logging,
     progress: function () {
       return progress(state)
     },
     request: function (id, follows) {
       if (opts.isFeed && !opts.isFeed(id)) return
-      self.state = events.follow(self.state, {id: id, value: follows !== false, ts: timestamp()})
+      self.state = events.follow(self.state, { id, value: follows !== false, ts: timestamp() })
       self.update()
     },
     pause: function (id, paused) {
-      self.state = events.pause(self.state, {id, paused: paused !== false})
+      self.state = events.pause(self.state, { id, paused: paused !== false })
       self.update()
     },
     block: function (id, target, value) {
-      self.state = events.block(self.state, {id, target, value: value !== false, ts: timestamp()})
+      self.state = events.block(self.state, { id, target, value: value !== false, ts: timestamp() })
       self.update()
     },
     createStream: function (remoteId, version, client) {
-      if (self.streams[remoteId])
-        self.streams[remoteId].end({name: 'Error', message: 'reconnected to peer', stack: ''})
+      if (self.streams[remoteId]) { self.streams[remoteId].end({ name: 'Error', message: 'reconnected to peer', stack: '' }) }
       if (self.logging) console.log('EBT:conn', remoteId)
-      function onClose(peerState) {
+      function onClose (peerState) {
         opts.setClock(remoteId, peerState.clock)
       }
-      var stream = new Stream(this, remoteId, version, client, opts.isMsg, onClose)
+      const stream = new Stream(this, remoteId, version, client, opts.isMsg, onClose)
       self.streams[remoteId] = stream
 
       opts.getClock(remoteId, (err, clock) => {
-        //check if peer exists in state, because we may
-        //have disconect in the meantime
-        if (self.state.peers[remoteId])
-          stream.clock(err ? {} : clock)
+        // check if peer exists in state, because we may
+        // have disconect in the meantime
+        if (self.state.peers[remoteId]) { stream.clock(err ? {} : clock) }
       })
 
       return stream
@@ -67,8 +65,8 @@ module.exports = function (opts) {
         self.state = events.retrive(self.state, msg)
         self.update()
       } else {
-        //this should never happen.
-        //replication for this feed is in bad state now.
+        // this should never happen.
+        // replication for this feed is in bad state now.
         console.log('could not retrive msg:', err)
       }
     },
@@ -77,24 +75,25 @@ module.exports = function (opts) {
       self.update()
     },
     update: function () {
-      //retrive next messages.
-      //TODO: respond to back pressure from streams to each peer.
-      //if a given stream is paused, don't retrive more msgs
-      //for that peer/stream.
-      for (var peer in self.state.peers) {
-        var state = self.state.peers[peer]
+      // retrive next messages.
+      // TODO: respond to back pressure from streams to each peer.
+      // if a given stream is paused, don't retrive more msgs
+      // for that peer/stream.
+      for (const peer in self.state.peers) {
+        const state = self.state.peers[peer]
         while (state.retrive.length) {
-          var id = state.retrive.shift()
-          if (state.replicating[id])
+          const id = state.retrive.shift()
+          if (state.replicating[id]) {
             opts.getAt({
               id,
-              sequence: state.replicating[id].sent+1
+              sequence: state.replicating[id].sent + 1
             }, self._retrive)
+          }
         }
       }
 
       if (self.state.receive.length) {
-        var ev = self.state.receive.shift()
+        const ev = self.state.receive.shift()
         opts.append(ev.value, function (err) {
           if (err) {
             if (self.logging) console.error('EBT:err', err)
@@ -103,13 +102,12 @@ module.exports = function (opts) {
         })
       }
 
-      for (var k in self.streams)
-        self.streams[k].resume()
-    },
+      for (const k in self.streams) { self.streams[k].resume() }
+    }
   }
 
-  var int = setInterval(() => {
-    self.state = events.timeout(self.state, {ts: timestamp()})
+  const int = setInterval(() => {
+    self.state = events.timeout(self.state, { ts: timestamp() })
     self.update()
   }, state.timeout)
   if (int.unref) int.unref()

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "push-stream": "^11.0.0"
   },
   "devDependencies": {
-    "rng": "^0.2.2",
     "bipf": "^1.3.0",
+    "rng": "^0.2.2",
+    "standard": "^17.0.0",
     "tape": "^4.6.3"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "set -e; for t in test/*.js; do node $t; done",
+    "lint": "standard --fix"
   },
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/progress.js
+++ b/progress.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /*
   better progress algorithm:
 
@@ -8,21 +9,21 @@
 */
 
 module.exports = function (state) {
-  var prog = { start: 0, current: 0, target: 0 }
-  for (var peer_id in state.peers) {
-    var peer = state.peers[peer_id]
+  const prog = { start: 0, current: 0, target: 0 }
+  for (const peer_id in state.peers) {
+    const peer = state.peers[peer_id]
 
-    for (var feed_id in peer.replicating) {
-      var rep = peer.replicating[feed_id]
-      //progress for sending initial note
+    for (const feed_id in peer.replicating) {
+      const rep = peer.replicating[feed_id]
+      // progress for sending initial note
       prog.target++
       if (rep.sent != null) prog.current++
 
       prog.target++
       if (rep.requested != null) prog.current++
 
-      var seq = peer.clock[feed_id]
-      var lseq = state.clock[feed_id] || 0
+      const seq = peer.clock[feed_id]
+      const lseq = state.clock[feed_id] || 0
 
       if (rep.rx && rep.requested != null && rep.requested > -1 && lseq < seq) {
         prog.current += lseq - rep.requested

--- a/test/binary.js
+++ b/test/binary.js
@@ -1,22 +1,22 @@
-var createSimulator = require('./simulator')
-var bipf = require("bipf")
-var events = require('../events')(require('../v3'))
+const createSimulator = require('./simulator')
+const bipf = require('bipf')
+const events = require('../events')(require('../v3'))
 
-function encode(data) {
-  var len = bipf.encodingLength(data)
-  var b = Buffer.alloc(len)
+function encode (data) {
+  const len = bipf.encodingLength(data)
+  const b = Buffer.alloc(len)
   bipf.encode(data, b, 0)
   return b
 }
 
-function getMsgAuthor(msg) {
-  var p = 0 // note you pass in p!
+function getMsgAuthor (msg) {
+  let p = 0 // note you pass in p!
   p = bipf.seekKey(msg, p, Buffer.from('author'))
   return bipf.decode(msg, p)
 }
 
-function getMsgSequence(msg) {
-  var p = 0 // note you pass in p!
+function getMsgSequence (msg) {
+  let p = 0 // note you pass in p!
   p = bipf.seekKey(msg, p, Buffer.from('sequence'))
   return bipf.decode(msg, p)
 }
@@ -24,43 +24,43 @@ function getMsgSequence(msg) {
 events.getMsgAuthor = getMsgAuthor
 events.getMsgSequence = getMsgSequence
 
-var test = require('tape')
+const test = require('tape')
 
 test('binary test', function (t) {
-  var tick = createSimulator(0, true, events)
+  const tick = createSimulator(0, true, events)
 
-  var network = {}
-  var alice = network['alice'] = tick.createPeer('alice')
-  var bob = network['bob'] = tick.createPeer('bob')
+  const network = {}
+  const alice = network.alice = tick.createPeer('alice')
+  const bob = network.bob = tick.createPeer('bob')
 
-  alice.append = function(msg) {
-    var ary = alice.store[getMsgAuthor(msg)] = alice.store[getMsgAuthor(msg)] || []
-    if(getMsgSequence(msg) === ary.length + 1) {
+  alice.append = function (msg) {
+    const ary = alice.store[getMsgAuthor(msg)] = alice.store[getMsgAuthor(msg)] || []
+    if (getMsgSequence(msg) === ary.length + 1) {
       ary.push(msg)
       alice.state = events.append(alice.state, msg)
     }
   }
-  bob.append = function(msg) {
-    var ary = bob.store[getMsgAuthor(msg)] = bob.store[getMsgAuthor(msg)] || []
-    if(getMsgSequence(msg) === ary.length + 1) {
+  bob.append = function (msg) {
+    const ary = bob.store[getMsgAuthor(msg)] = bob.store[getMsgAuthor(msg)] || []
+    if (getMsgSequence(msg) === ary.length + 1) {
       ary.push(msg)
       bob.state = events.append(bob.state, msg)
     }
   }
-  
+
   alice.init({})
   bob.init({})
 
-  alice.append(encode({author: 'alice', sequence: 1, text: "test"}))
-  alice.append(encode({author: 'alice', sequence: 2, text: "test2"}))
-  alice.append(encode({author: 'alice', sequence: 3, text: "test3"}))
+  alice.append(encode({ author: 'alice', sequence: 1, text: 'test' }))
+  alice.append(encode({ author: 'alice', sequence: 2, text: 'test2' }))
+  alice.append(encode({ author: 'alice', sequence: 3, text: 'test3' }))
 
   alice.follow('alice')
   bob.follow('alice')
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   t.deepEqual(bob.store, alice.store)
   t.end()

--- a/test/block.js
+++ b/test/block.js
@@ -1,47 +1,49 @@
-var test = require('tape')
+const test = require('tape')
 
-var events = require('../events')(require('./options'))
+const events = require('../events')(require('./options'))
 
-var note = events.note
+const note = events.note
 
 test('blocks', function (t) {
+  let state = events.initialize('alice')
 
-  var state = events.initialize('alice')
+  state.clock = { alice: 3, charles: 3, dawn: 3 }
 
-  state.clock = {alice: 3, charles: 3, dawn: 3}
+  state = events.follow(state, { id: 'alice', value: true })
+  state = events.follow(state, { id: 'charles', value: true })
+  state = events.follow(state, { id: 'dawn', value: true })
 
-  state = events.follow(state, {id: 'alice', value: true})
-  state = events.follow(state, {id: 'charles', value: true})
-  state = events.follow(state, {id: 'dawn', value: true})
-
-  state = events.block(state, {id: 'alice', target: 'bob', value: true})
-  t.deepEqual(state.blocks, {alice: {bob:true}})
-  state = events.block(state, {id: 'alice', target: 'bob', value: false})
+  state = events.block(state, { id: 'alice', target: 'bob', value: true })
+  t.deepEqual(state.blocks, { alice: { bob: true } })
+  state = events.block(state, { id: 'alice', target: 'bob', value: false })
   t.deepEqual(state.blocks, {})
 
-  //do not allow connection to someone we block.
-  state = events.block(state, {id: 'alice', target: 'bob', value: true})
-  state = events.block(state, {id: 'charles', target: 'dawn', value: true})
+  // do not allow connection to someone we block.
+  state = events.block(state, { id: 'alice', target: 'bob', value: true })
+  state = events.block(state, { id: 'charles', target: 'dawn', value: true })
   console.log(state)
-  state = events.connect(state, {id: 'bob', client: false})
+  state = events.connect(state, { id: 'bob', client: false })
 
   t.equal(state.peers.bob.blocked, true)
 
-  state = events.connect(state, {id: 'dawn', client: false})
+  state = events.connect(state, { id: 'dawn', client: false })
 
-  state = events.peerClock(state, {id: 'dawn', value:{}})
+  state = events.peerClock(state, { id: 'dawn', value: {} })
 
-  //charles has blocked dawn, so do not give dawn charle's messages
+  // charles has blocked dawn, so do not give dawn charle's messages
   t.deepEqual(state.peers.dawn.notes, {
     alice: note(3, true), dawn: note(3, true)
   })
 
-  //but dawn asks for charles anyway.
-  state = events.notes(state, {id: 'dawn', value: {
-    alice: note(2, true), dawn: note(2, true), charles: note(1, true)
-  }})
+  // but dawn asks for charles anyway.
+  state = events.notes(state, {
+    id: 'dawn',
+    value: {
+      alice: note(2, true), dawn: note(2, true), charles: note(1, true)
+    }
+  })
 
-  //charles has blocked dawn, so do not give dawn charles' messages
+  // charles has blocked dawn, so do not give dawn charles' messages
   t.deepEqual(state.peers.dawn.notes, {
     alice: note(3, true), dawn: note(3, true), charles: note(-1, false)
   })
@@ -50,31 +52,31 @@ test('blocks', function (t) {
 })
 
 test("don't send retrived message to blocked peer", function (t) {
-  var state = events.initialize('alice')
-  state.clock = {alice: 3, charles: 2}
-//  state.block = {charles: {bob: true}} //charles blocks bob
-  state = events.block(state, {id: 'charles', target: 'bob', value: true})
-  state = events.connect(state, {id: 'bob', ts: 1, client: false})
+  let state = events.initialize('alice')
+  state.clock = { alice: 3, charles: 2 }
+  //  state.block = {charles: {bob: true}} //charles blocks bob
+  state = events.block(state, { id: 'charles', target: 'bob', value: true })
+  state = events.connect(state, { id: 'bob', ts: 1, client: false })
   console.log(state)
-  state = events.peerClock(state, {id: 'bob', value: {}})
-  state = events.notes(state, {id: 'bob', value: {charles: 1}})
+  state = events.peerClock(state, { id: 'bob', value: {} })
+  state = events.notes(state, { id: 'bob', value: { charles: 1 } })
   t.equal(state.peers.bob.replicating.charles.tx, false)
   t.equal(state.peers.bob.replicating.charles.sent, -1)
   console.log('state', JSON.stringify(state, null, 2))
 
-  //it's already in a state that the peer should be blocked.
+  // it's already in a state that the peer should be blocked.
 
   t.end()
 })
 
 test("don't send retrived message to blocked peer", function (t) {
-  var state = events.initialize('alice')
-  state.clock = {alice: 3, charles: 2}
-  state = events.connect(state, {id: 'bob', ts: 1, client: false})
-  state = events.peerClock(state, {id: 'bob', value: {}})
+  let state = events.initialize('alice')
+  state.clock = { alice: 3, charles: 2 }
+  state = events.connect(state, { id: 'bob', ts: 1, client: false })
+  state = events.peerClock(state, { id: 'bob', value: {} })
 
-  state = events.notes(state, {id: 'bob', value: {charles: 1}})
-  state = events.block(state, {id: 'charles', target: 'bob', value: true})
+  state = events.notes(state, { id: 'bob', value: { charles: 1 } })
+  state = events.block(state, { id: 'charles', target: 'bob', value: true })
 
   t.equal(state.peers.bob.replicating.charles.tx, false)
   t.equal(state.peers.bob.replicating.charles.sent, -1)
@@ -82,24 +84,21 @@ test("don't send retrived message to blocked peer", function (t) {
   t.end()
 })
 
-test("blocking false on a connected peer does nothing", function (t) {
-  var state = events.initialize('alice')
-  state.clock = {alice: 3, charles: 2}
-  state = events.connect(state, {id: 'charles', ts: 1, client: false})
-  //state = events.peerClock(state, {id: 'charles', value: { charles: 2 }})
-  state = events.peerClock(state, {id: 'charles', value: {'alice': 0, 'charles': 0}})
+test('blocking false on a connected peer does nothing', function (t) {
+  let state = events.initialize('alice')
+  state.clock = { alice: 3, charles: 2 }
+  state = events.connect(state, { id: 'charles', ts: 1, client: false })
+  // state = events.peerClock(state, {id: 'charles', value: { charles: 2 }})
+  state = events.peerClock(state, { id: 'charles', value: { alice: 0, charles: 0 } })
 
-  state = events.follow(state, {id: 'alice', value: true})
-  state = events.follow(state, {id: 'charles', value: true})
+  state = events.follow(state, { id: 'alice', value: true })
+  state = events.follow(state, { id: 'charles', value: true })
 
-  state = events.notes(state, {id: 'charles', value: {charles: 2}})
-  const existingNote = state.peers['charles'].notes['alice']
+  state = events.notes(state, { id: 'charles', value: { charles: 2 } })
+  const existingNote = state.peers.charles.notes.alice
   // this should not change anything
-  state = events.block(state, {id: 'alice', target: 'charles', value: false})
-  t.equal(state.peers['charles'].notes['alice'], existingNote)
+  state = events.block(state, { id: 'alice', target: 'charles', value: false })
+  t.equal(state.peers.charles.notes.alice, existingNote)
 
   t.end()
 })
-
-
-

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,26 +1,26 @@
 
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
 
-var test = require('tape')
+const test = require('tape')
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var charles = network['charles'] = tick.createPeer('charles')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const charles = network.charles = tick.createPeer('charles')
 
     alice.init({})
     bob.init({})
     charles.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
 
     alice.follow('alice')
     bob.follow('alice')
@@ -29,15 +29,15 @@ function createTest (seed, log) {
     alice.connect(bob)
     bob.connect(charles)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, bob.store, 'charles<->bob')
 
     function isComplete (peer) {
-      var prog = progress(peer.state)
+      const prog = progress(peer.state)
       t.equal(prog.current, prog.target)
     }
 
@@ -49,14 +49,7 @@ function createTest (seed, log) {
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++)
-    createTest(i, false)
-else
-  createTest(+seed, true)
-
-
-
-
-
+const seed = process.argv[2]
+if (isNaN(seed)) {
+  for (let i = 0; i < 100; i++) { createTest(i, false) }
+} else { createTest(+seed, true) }

--- a/test/client.js
+++ b/test/client.js
@@ -1,18 +1,18 @@
-var test = require('tape')
+const test = require('tape')
 
-var events = require('../events')(require('./options'))
+const events = require('../events')(require('./options'))
 
-var note = events.note
+const note = events.note
 
 test('client does not send {} until received it', function (t) {
-  var state = events.initialize('alice')
-  state = events.connect(state, {id: 'bob', client: true})
-  state.follows = {alice: true, bob: true}
-  state.clock = {alice:1, bob: 1}
-  state = events.peerClock(state, {id: 'bob', value: {}})
+  let state = events.initialize('alice')
+  state = events.connect(state, { id: 'bob', client: true })
+  state.follows = { alice: true, bob: true }
+  state.clock = { alice: 1, bob: 1 }
+  state = events.peerClock(state, { id: 'bob', value: {} })
   t.equal(state.peers.bob.notes, null)
-  state = events.notes(state, {id: 'bob', value: {}})
-  t.deepEqual(state.peers.bob.notes, {alice: note(1, true), bob: note(1, true)})
+  state = events.notes(state, { id: 'bob', value: {} })
+  t.deepEqual(state.peers.bob.notes, { alice: note(1, true), bob: note(1, true) })
 
   state.peers.bob.notes = null
 
@@ -20,11 +20,11 @@ test('client does not send {} until received it', function (t) {
 })
 
 test('client does not send {} until received it, but will send empty note, one time', function (t) {
-  var state = events.initialize('alice')
-  state = events.connect(state, {id: 'bob', client: true})
-  state = events.peerClock(state, {id: 'bob', value: {}})
+  let state = events.initialize('alice')
+  state = events.connect(state, { id: 'bob', client: true })
+  state = events.peerClock(state, { id: 'bob', value: {} })
   t.equal(state.peers.bob.notes, null)
-  state = events.notes(state, {id: 'bob', value: {}})
+  state = events.notes(state, { id: 'bob', value: {} })
   t.deepEqual(state.peers.bob.notes, {})
   t.end()
 })

--- a/test/disconnect.js
+++ b/test/disconnect.js
@@ -1,26 +1,27 @@
 
-var createSimulator = require('./simulator')
-var _events = require('../events')(require('./options'))
-var test = require('tape')
-var progress = require('../progress')
-var events = {}
-for(var k in _events) (function (fn, k) {
-  events[k] = function (state, ev) {
-    if(state.stalled) return state
-    return fn(state, ev)
-  }
-})(_events[k], k)
-
+const createSimulator = require('./simulator')
+const _events = require('../events')(require('./options'))
+const test = require('tape')
+const progress = require('../progress')
+const events = {}
+for (const k in _events) {
+  (function (fn, k) {
+    events[k] = function (state, ev) {
+      if (state.stalled) return state
+      return fn(state, ev)
+    }
+  })(_events[k], k)
+}
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var carl = network['carl'] = tick.createPeer('carl')
-    var dawn = network['dawn'] = tick.createPeer('dawn')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const carl = network.carl = tick.createPeer('carl')
+    const dawn = network.dawn = tick.createPeer('dawn')
 
     alice.state.timeout = bob.state.timeout = dawn.state.timeout = 2
     alice.init({})
@@ -28,10 +29,10 @@ function createTest (seed, log) {
     carl.init({})
     dawn.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
-    bob.append({author: 'bob', sequence: 1, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
+    bob.append({ author: 'bob', sequence: 1, content: {} })
 
     alice.follow('alice')
     alice.follow('bob')
@@ -49,14 +50,13 @@ function createTest (seed, log) {
     dawn.connect(bob)
 
     tick.run(network)
-//    carl.state.stalled = true
+    //    carl.state.stalled = true
 
-//    alice.disconnect(carl)
+    //    alice.disconnect(carl)
     bob.disconnect(carl)
-//    dawn.disconnect(carl)
+    //    dawn.disconnect(carl)
 
-    alice.append({author: 'alice', sequence: 4, content: {}})
-
+    alice.append({ author: 'alice', sequence: 4, content: {} })
 
     tick.run(network)
 
@@ -64,8 +64,8 @@ function createTest (seed, log) {
     t.deepEqual(bob.store, alice.store, 'bob matches alice')
 
     function isComplete (peer, name) {
-      var prog = progress(peer.state)
-      t.equal(prog.current, prog.target, name +' is complete')
+      const prog = progress(peer.state)
+      t.equal(prog.current, prog.target, name + ' is complete')
     }
 
     isComplete(alice, 'alice')
@@ -76,7 +76,5 @@ function createTest (seed, log) {
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++) createTest(i)
-else createTest(+seed, true)
+const seed = process.argv[2]
+if (isNaN(seed)) { for (let i = 0; i < 100; i++) createTest(i) } else createTest(+seed, true)

--- a/test/fork.js
+++ b/test/fork.js
@@ -1,75 +1,72 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
 
-var test = require('tape')
+const test = require('tape')
 
 function validate (queue, msg) {
-  var sum = queue.reduce(function (a, b) {
+  const sum = queue.reduce(function (a, b) {
     return a + b.content.value
   }, 0)
-  if(sum != msg.content.sum) throw new Error('invalid sum:'+msg.content.sum+', expected:'+sum)
+  if (sum !== msg.content.sum) throw new Error('invalid sum:' + msg.content.sum + ', expected:' + sum)
 }
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice', validate)
-    var bob = network['bob'] = tick.createPeer('bob', validate)
-  //  var charles = network['charles'] = tick.createPeer('charles', validate)
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice', validate)
+    const bob = network.bob = tick.createPeer('bob', validate)
+    //  var charles = network['charles'] = tick.createPeer('charles', validate)
 
     alice.init({})
     bob.init({})
-//    charles.init({})
+    //    charles.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {sum:  0, value: 1}})
-    alice.append({author: 'alice', sequence: 2, content: {sum:  1, value: 2}})
-    alice.append({author: 'alice', sequence: 3, content: {sum:  3, value: 3}})
-    alice.append({author: 'alice', sequence: 4, content: {sum:  6, value: 4}})
-    alice.append({author: 'alice', sequence: 5, content: {sum: 10, value: 5}})
-    alice.append({author: 'alice', sequence: 6, content: {sum: 15, value: 6}})
-    alice.append({author: 'alice', sequence: 7, content: {sum: 21, value: 7}})
+    alice.append({ author: 'alice', sequence: 1, content: { sum: 0, value: 1 } })
+    alice.append({ author: 'alice', sequence: 2, content: { sum: 1, value: 2 } })
+    alice.append({ author: 'alice', sequence: 3, content: { sum: 3, value: 3 } })
+    alice.append({ author: 'alice', sequence: 4, content: { sum: 6, value: 4 } })
+    alice.append({ author: 'alice', sequence: 5, content: { sum: 10, value: 5 } })
+    alice.append({ author: 'alice', sequence: 6, content: { sum: 15, value: 6 } })
+    alice.append({ author: 'alice', sequence: 7, content: { sum: 21, value: 7 } })
 
-    bob.append({author: 'alice', sequence: 1, content: {sum: 0, value: 1}})
-    bob.append({author: 'alice', sequence: 2, content: {sum: 1, value: 3}})
-//    bob.append({author: 'alice', sequence: 3, content: {sum: 4, value: 1}})
+    bob.append({ author: 'alice', sequence: 1, content: { sum: 0, value: 1 } })
+    bob.append({ author: 'alice', sequence: 2, content: { sum: 1, value: 3 } })
+    //    bob.append({author: 'alice', sequence: 3, content: {sum: 4, value: 1}})
 
     alice.follow('alice')
     bob.follow('alice')
-  //  charles.follow('alice')
+    //  charles.follow('alice')
 
     alice.connect(bob)
-//    alice.connect(charles)
+    //    alice.connect(charles)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
-    t.deepEqual(bob.state.blocks, {alice: {alice: true}})
+    t.deepEqual(bob.state.blocks, { alice: { alice: true } })
 
-    var prog = progress(bob.state)
+    const prog = progress(bob.state)
     t.equal(prog.current, prog.target)
 
-//    t.equal(bob.state.peers.alice.replicating.alice.tx, false, 'bob is not transmitting forked alice with alice')
+    //    t.equal(bob.state.peers.alice.replicating.alice.tx, false, 'bob is not transmitting forked alice with alice')
     t.equal(bob.state.peers.alice.replicating.alice.rx, false, 'bob is not receiving forked alice with alice')
 
-    if(log)
+    if (log) {
       console.log(
         tick.output.map(function (e) {
-          if(e.msg)
-            return e.from+'>'+e.to+':'+e.value.sequence
-          else
-            return e.from+'>'+e.to+':'+JSON.stringify(e.value)
+          if (e.msg) { return e.from + '>' + e.to + ':' + e.value.sequence } else { return e.from + '>' + e.to + ':' + JSON.stringify(e.value) }
         }).join('\n')
       )
+    }
 
     t.end()
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed)) for(var i = 0; i < 100; i++) createTest(i)
+const seed = process.argv[2]
+if (isNaN(seed)) for (let i = 0; i < 100; i++) createTest(i)
 else createTest(+seed, true)
-

--- a/test/index.js
+++ b/test/index.js
@@ -1,509 +1,505 @@
-var test = require('tape')
+const test = require('tape')
 
-function isObject(o) {
-  return o && 'object' === typeof o
+function isObject (o) {
+  return o && typeof o === 'object'
 }
 
 function isFunction (f) {
-  return 'function' === typeof f
+  return typeof f === 'function'
 }
 
 function is (t, actual, expected, path) {
-  if(isFunction(expected))
-    expected.call(actual)
-  else t.equal(expected, actual, 'expected '+path.join('.')+' to equal:'+actual)
+  if (isFunction(expected)) { expected.call(actual) } else t.equal(expected, actual, 'expected ' + path.join('.') + ' to equal:' + actual)
 }
 
 function has (t, actual, expected, path) {
   path = path || []
 
-  if(!(isObject(actual))) return is(t, actual, expected, path)
+  if (!(isObject(actual))) return is(t, actual, expected, path)
 
-  if(!isObject(expected))
-    return t.fail('expected object at path:'+path.join('.'))
+  if (!isObject(expected)) { return t.fail('expected object at path:' + path.join('.')) }
 
-  for(var k in expected)
-    has(t, actual[k], expected[k], path.concat(k))
+  for (const k in expected) { has(t, actual[k], expected[k], path.concat(k)) }
 }
 
 module.exports = function (events) {
+  const note = events.note
 
-var note = events.note
+  test('initialize, connect to new peer', function (t) {
+    let state = events.initialize()
 
-test('initialize, connect to new peer', function (t) {
+    state = events.connect(state, { id: 'alice', client: false })
+    state = events.peerClock(state, { id: 'alice', value: {} })
 
-  var state = events.initialize()
+    has(t, state, {
+      peers: {
+        alice: { clock: {}, msgs: [], notes: {}, replicating: {} }
+      }
+    })
 
-  state = events.connect(state, {id: 'alice', client: false})
-  state = events.peerClock(state, {id: 'alice', value: {}})
+    state = events.clock(state, {})
 
-  has(t, state, {
-    peers: {
-      alice: { clock: {}, msgs: [], notes: {}, replicating: {} },
-    }
-  })
+    state = events.follow(state, { id: 'alice', value: true })
 
-  state = events.clock(state, {})
+    t.deepEqual(state.follows, { alice: true })
+    console.log(state.peers.alice)
 
-  state = events.follow(state, {id: 'alice', value: true})
+    has(t, state.peers.alice, {
+      clock: {},
+      notes: { alice: note(0, true) },
+      replicating: { alice: { rx: true } }
+    }, ['state', 'peers', 'alice'])
 
-  t.deepEqual(state.follows, {alice: true})
-  console.log(state.peers.alice)
+    // lets say we send the note
 
-  has(t, state.peers.alice, {
-    clock: {},
-    notes: { alice: note(0, true) },
-    replicating: {alice: {rx: true}}
-  }, ['state', 'peers', 'alice'])
-
-  //lets say we send the note
-
-  state = events.notes(state, {id: 'alice', value: {alice: note(2, true)}})
-  has(t, state, {
-    clock: {},
-    follows: {alice: true},
-    peers: {
-      alice: {
-        clock: {alice: 2},
-        replicating: {
-          alice: {
-            rx: true, tx: true
+    state = events.notes(state, { id: 'alice', value: { alice: note(2, true) } })
+    has(t, state, {
+      clock: {},
+      follows: { alice: true },
+      peers: {
+        alice: {
+          clock: { alice: 2 },
+          replicating: {
+            alice: {
+              rx: true, tx: true
+            }
           }
         }
       }
-    }
-  })
+    })
 
-  var msg = {author: 'alice', sequence: 1, content: {}}
-  state = events.receive(state, {id: 'alice', value:msg})
+    const msg = { author: 'alice', sequence: 1, content: {} }
+    state = events.receive(state, { id: 'alice', value: msg })
 
-  has(t, state, {
-    peers: {
-      alice: {
-        clock: {alice: 2},
-        replicating: {
-          alice: {
-            rx: true, tx: true
-          }
-        }
-      }
-    },
-    receive: [{id: 'alice', value: msg}],
-  })
-
-  var ev = state.receive.shift()
-
-  state = events.append(state, ev.value)
-
-  has(t, state, {
-    clock: {alice: 1}
-  })
-
-  var msg2 = {author: 'alice', sequence: 2, content: {}}
-  state = events.receive(state, {id: 'alice', value:msg2})
-  state = events.append(state, state.receive.shift().value)
-
-  has(t, state, {
-    clock: {alice: 2}
-  })
-
-  var msg3 = {author: 'alice', sequence: 3, content: {}}
-  state = events.receive(state, {id: 'alice', value:msg3})
-  state = events.append(state, state.receive.shift().value)
-
-  has(t, state, {
-    clock: {alice: 3}
-  })
-
-  t.end()
-
-})
-
-test('initialize, but append before peerClock loads', function (t) {
-
-  var state = events.initialize()
-  state = events.clock(state, {alice: 1, bob: 2})
-
-  state = events.connect(state, {id: 'alice', client: false})
-  state = events.append(state, {author: 'bob', sequence: 3, content: {}})
-
-  state = events.peerClock(state, {id: 'alice', value: {}})
-  t.end()
-})
-
-test('connect to two peers, append message one send, one note', function (t) {
-
-  var state = {
-    clock: { alice: 1 },
-    follows: { alice: true },
-    blocks: {},
-    peers: {
-      bob: {
-        clock: { alice: 1 },
-        msgs: [], retrive: [],
-        replicating: {
-          alice: {
-            rx: true, tx: true, sent: 1, retrive: false
+    has(t, state, {
+      peers: {
+        alice: {
+          clock: { alice: 2 },
+          replicating: {
+            alice: {
+              rx: true, tx: true
+            }
           }
         }
       },
-      charles: {
-        clock: {alice: 1},
-        msgs: [], retrive: [],
-        replicating: {
-          alice: {
-            rx: false, tx: false, sent: 1, retrive: false
-          }
-        }
-      }
-    }
-  }
+      receive: [{ id: 'alice', value: msg }]
+    })
 
-  var msg = {author: 'alice', sequence: 2, content: {}}
-  state = events.append(state, msg)
+    const ev = state.receive.shift()
 
-  has(t, state, {
-    clock: { alice: 2 },
-    peers: {
-      bob: {
-        clock: { alice: 1 },
-        msgs: [msg],
-        retrive: [],
-        replicating: {
-          alice: {
-            rx: true, tx: true, sent: 2, retrive: false
-          }
-        }
-      },
-      charles: {
-        clock: { alice: 1 },
-        notes: { alice: note(2, false) },
-        retrive: [],
-        replicating: {
-          alice: {
-            rx: false, tx: false, sent: 1
-          }
-        }
-      }
-    }
+    state = events.append(state, ev.value)
+
+    has(t, state, {
+      clock: { alice: 1 }
+    })
+
+    const msg2 = { author: 'alice', sequence: 2, content: {} }
+    state = events.receive(state, { id: 'alice', value: msg2 })
+    state = events.append(state, state.receive.shift().value)
+
+    has(t, state, {
+      clock: { alice: 2 }
+    })
+
+    const msg3 = { author: 'alice', sequence: 3, content: {} }
+    state = events.receive(state, { id: 'alice', value: msg3 })
+    state = events.append(state, state.receive.shift().value)
+
+    has(t, state, {
+      clock: { alice: 3 }
+    })
+
+    t.end()
   })
 
-  t.end()
+  test('initialize, but append before peerClock loads', function (t) {
+    let state = events.initialize()
+    state = events.clock(state, { alice: 1, bob: 2 })
 
-})
+    state = events.connect(state, { id: 'alice', client: false })
+    state = events.append(state, { author: 'bob', sequence: 3, content: {} })
 
-test('replicate a hops=2 peer that my hops=1 friend still doesnt have', function (t) {
-  var state = events.initialize()
-  state = events.clock(state, {})
+    state = events.peerClock(state, { id: 'alice', value: {} })
+    // TODO does this test anything?
+    t.end()
+  })
 
-  state = events.connect(state, {id: 'alice', client: false})
-  state = events.peerClock(state, {id: 'alice', value: {'alice': 0, 'bob': 0}})
-
-  state = events.follow(state, {id: 'alice', value: true})
-  state = events.follow(state, {id: 'bob', value: true})
-
-  t.ok(state.peers['alice'].replicating['bob'])
-
-  t.end()
-})
-
-test('replicate a hops=2 peer that my hops=1 friend still doesnt have (2)', function (t) {
-  var state = events.initialize()
-  state = events.clock(state, {})
-
-  state = events.follow(state, {id: 'alice', value: true})
-  state = events.follow(state, {id: 'bob', value: true})
-
-  state = events.connect(state, {id: 'alice', client: false})
-  state = events.peerClock(state, {id: 'alice', value: {'alice': 0, 'bob': 0}})
-
-  t.ok(state.peers['alice'].replicating['bob'])
-
-  t.end()
-})
-
-test('reply to any clock they send, 1', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2, charles: 3 },
-    follows: { alice: true, bob: true, charles: true, darlene: false },
-    blocks: {},
-    peers: {}
-  }
-
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: 3, charles: 1}})
-  t.deepEqual(state.peers.bob.notes, {bob: note(2, true), charles: note(3, true)})
-
-  state = events.notes(state, {id: 'bob', value: {alice: note(3, true), darlene: note(4, true)}})
-
-  //notes hasn't been sent, so this is merged with previous
-  t.deepEqual(state.peers.bob.notes, {alice: note(3, false), bob: note(2, true), charles: note(3, true), darlene: note(-1, true)})
-
-  t.end()
-})
-
-test('reply to any clock they send, 2', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {},
-  }
-
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: 3, charles: 1}})
-  t.deepEqual(state.peers.bob.notes, {bob: note(2, true)})
-
-  state = events.notes(state, {id: 'bob', value: {alice: note(3, true)}})
-
-  //notes hasn't been sent, so this is merged with previous
-  t.deepEqual(state.peers.bob.notes, {alice: note(3, false), bob: note(2, true)})
-
-  state = events.follow(state, {id: 'charles',value: true})
-  t.deepEqual(state.peers.bob.notes, {alice: note(3, false), bob: note(2, true), charles: note(0, true)})
-
-  t.end()
-})
-
-test('append when not in TX mode', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {}
-  }
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: 3, charles: 1}})
-  t.deepEqual(state.peers.bob.notes, {bob: note(2, true)})
-
-  state = events.notes(state, {id: 'bob', value: {alice: note(3, false)}})
-  var rep = state.peers.bob.replicating.alice
-  t.equal(rep.tx, false)
-  t.equal(rep.sent, 3)
-
-  console.log(state.peers.bob.replicating)
-
-  state = events.append(state, {author: 'alice', sequence: 4, content: {}})
-  t.deepEqual(state.peers.bob.notes, {bob: note(2, true), alice: note(4, false)})
-  rep = state.peers.bob.replicating.alice
-  t.equal(rep.tx, false)
-  t.equal(rep.sent, 3)
-
-  state = events.notes(state, {id: 'bob', value: {alice: note(3, true)}})
-  t.deepEqual(state.peers.bob.retrive, ['alice'])
-
-  t.end()
-})
-
-test('note when not in RX mode', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {
-      bob: {
-        clock: {alice: 3, bob: 2},
-        retrive: [],
-        msgs: [],
-        notes: null,
-        replicating: {
-          alice: {
-            tx:false, rx: false, sent: 3
+  test('connect to two peers, append message one send, one note', function (t) {
+    let state = {
+      clock: { alice: 1 },
+      follows: { alice: true },
+      blocks: {},
+      peers: {
+        bob: {
+          clock: { alice: 1 },
+          msgs: [],
+          retrive: [],
+          replicating: {
+            alice: {
+              rx: true, tx: true, sent: 1, retrive: false
+            }
+          }
+        },
+        charles: {
+          clock: { alice: 1 },
+          msgs: [],
+          retrive: [],
+          replicating: {
+            alice: {
+              rx: false, tx: false, sent: 1, retrive: false
+            }
           }
         }
       }
     }
-  }
 
-  state = events.notes(state, {id: 'bob', value: {alice: note(5, false)}})
-  var rep = state.peers.bob.replicating.alice
-//  t.equal(rep.tx, true)
-  t.equal(rep.rx, true)
-  t.equal(rep.sent, 5)
-  t.deepEqual(state.peers.bob.notes, {alice: note(3, true)})
+    const msg = { author: 'alice', sequence: 2, content: {} }
+    state = events.append(state, msg)
 
-  console.log(state.peers.bob.replicating)
+    has(t, state, {
+      clock: { alice: 2 },
+      peers: {
+        bob: {
+          clock: { alice: 1 },
+          msgs: [msg],
+          retrive: [],
+          replicating: {
+            alice: {
+              rx: true, tx: true, sent: 2, retrive: false
+            }
+          }
+        },
+        charles: {
+          clock: { alice: 1 },
+          notes: { alice: note(2, false) },
+          retrive: [],
+          replicating: {
+            alice: {
+              rx: false, tx: false, sent: 1
+            }
+          }
+        }
+      }
+    })
 
-//  state = events.append(state, {author: 'alice', sequence: 4, content: {}})
-//  t.deepEqual(state.peers.bob.notes, {bob: note(2, true), alice: note(4, false)})
-  t.end()
+    t.end()
+  })
 
-})
+  test('replicate a hops=2 peer that my hops=1 friend still doesnt have', function (t) {
+    let state = events.initialize()
+    state = events.clock(state, {})
 
-test('note when value is not integer', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {}
-  }
+    state = events.connect(state, { id: 'alice', client: false })
+    state = events.peerClock(state, { id: 'alice', value: { alice: 0, bob: 0 } })
 
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{}})
+    state = events.follow(state, { id: 'alice', value: true })
+    state = events.follow(state, { id: 'bob', value: true })
 
-  t.deepEqual(state.peers.bob.clock, {})
-  state = events.notes(state, {id: 'bob', value: {alice: true}})
+    t.ok(state.peers.alice.replicating.bob)
 
-  t.deepEqual(state.peers.bob.clock, {alice: -1})
-  t.deepEqual(state.peers.bob.notes, {alice: note(3,true), bob: note(2, true)})
+    t.end()
+  })
 
-  t.end()
-})
+  test('replicate a hops=2 peer that my hops=1 friend still doesnt have (2)', function (t) {
+    let state = events.initialize()
+    state = events.clock(state, {})
 
-test('test sends empty clock if nothing needed', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {}
-  }
+    state = events.follow(state, { id: 'alice', value: true })
+    state = events.follow(state, { id: 'bob', value: true })
 
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: 3, bob: 2}})
+    state = events.connect(state, { id: 'alice', client: false })
+    state = events.peerClock(state, { id: 'alice', value: { alice: 0, bob: 0 } })
 
-  t.deepEqual(state.peers.bob.clock, {alice: 3, bob: 2})
-  t.deepEqual(state.peers.bob.notes, {})
+    t.ok(state.peers.alice.replicating.bob)
 
-  //receive empty clock
-  state = events.notes(state, {id: 'bob', value: {}})
-  t.deepEqual(state.peers.bob.replicating, {})
+    t.end()
+  })
 
-  t.end()
-})
+  test('reply to any clock they send, 1', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2, charles: 3 },
+      follows: { alice: true, bob: true, charles: true, darlene: false },
+      blocks: {},
+      peers: {}
+    }
 
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 3, charles: 1 } })
+    t.deepEqual(state.peers.bob.notes, { bob: note(2, true), charles: note(3, true) })
 
-test('connects in sync then another message', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: { alice: true, bob: true}, blocks: {},
-    peers: {}
-  }
+    state = events.notes(state, { id: 'bob', value: { alice: note(3, true), darlene: note(4, true) } })
 
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: 3, bob: 2}})
+    // notes hasn't been sent, so this is merged with previous
+    t.deepEqual(state.peers.bob.notes, { alice: note(3, false), bob: note(2, true), charles: note(3, true), darlene: note(-1, true) })
 
-  t.deepEqual(state.peers.bob.clock, {alice: 3, bob: 2})
-  t.deepEqual(state.peers.bob.notes, {})
+    t.end()
+  })
 
-  //receive empty clock
-  state = events.notes(state, {id: 'bob', value: {}})
-  t.deepEqual(state.peers.bob.replicating, {})
+  test('reply to any clock they send, 2', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {}
+    }
 
-  state = events.append(state, {author: 'alice', sequence: 4, content: {}})
-  t.deepEqual(state.peers.bob.notes, {alice: note(4, false)})
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 3, charles: 1 } })
+    t.deepEqual(state.peers.bob.notes, { bob: note(2, true) })
 
-  t.end()
-})
+    state = events.notes(state, { id: 'bob', value: { alice: note(3, true) } })
 
-test('unfollow', function (t) {
+    // notes hasn't been sent, so this is merged with previous
+    t.deepEqual(state.peers.bob.notes, { alice: note(3, false), bob: note(2, true) })
 
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: {}, blocks: {},
-    peers: {}
-  }
+    state = events.follow(state, { id: 'charles', value: true })
+    t.deepEqual(state.peers.bob.notes, { alice: note(3, false), bob: note(2, true), charles: note(0, true) })
 
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{}})
+    t.end()
+  })
 
-  t.deepEqual(state.peers.bob.clock, {})
-  t.deepEqual(state.peers.bob.notes, { })
-  state = events.notes(state, {id: 'bob', value:{alice: note(3, true), bob: note(2, true)}})
-  t.deepEqual(state.peers.bob.notes, { alice: note(-1, true), bob: note(-1, true)})
+  test('append when not in TX mode', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {}
+    }
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 3, charles: 1 } })
+    t.deepEqual(state.peers.bob.notes, { bob: note(2, true) })
 
-  state.peers.bob.notes = null
+    state = events.notes(state, { id: 'bob', value: { alice: note(3, false) } })
+    let rep = state.peers.bob.replicating.alice
+    t.equal(rep.tx, false)
+    t.equal(rep.sent, 3)
 
-  state = events.follow(state, {id: 'alice', value: false})
+    console.log(state.peers.bob.replicating)
 
-  t.deepEqual(state.peers.bob.notes, null)
+    state = events.append(state, { author: 'alice', sequence: 4, content: {} })
+    t.deepEqual(state.peers.bob.notes, { bob: note(2, true), alice: note(4, false) })
+    rep = state.peers.bob.replicating.alice
+    t.equal(rep.tx, false)
+    t.equal(rep.sent, 3)
 
-  state = events.notes(state, {id: 'bob', value:{charles: note(-1, true)}})
-  t.deepEqual(state.peers.bob.notes, {charles: note(-1, true)})
-  state.peers.bob.notes = null
-  state = events.notes(state, {id: 'bob', value:{charles: note(-1, true)}})
-  t.deepEqual(state.peers.bob.notes, null)
+    state = events.notes(state, { id: 'bob', value: { alice: note(3, true) } })
+    t.deepEqual(state.peers.bob.retrive, ['alice'])
 
-  t.end()
-})
+    t.end()
+  })
 
+  test('note when not in RX mode', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {
+        bob: {
+          clock: { alice: 3, bob: 2 },
+          retrive: [],
+          msgs: [],
+          notes: null,
+          replicating: {
+            alice: {
+              tx: false, rx: false, sent: 3
+            }
+          }
+        }
+      }
+    }
 
-test('remember clock of unfollow', function (t) {
+    state = events.notes(state, { id: 'bob', value: { alice: note(5, false) } })
+    const rep = state.peers.bob.replicating.alice
+    //  t.equal(rep.tx, true)
+    t.equal(rep.rx, true)
+    t.equal(rep.sent, 5)
+    t.deepEqual(state.peers.bob.notes, { alice: note(3, true) })
 
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: {alice: true}, blocks: {},
-    peers: {}
-  }
+    console.log(state.peers.bob.replicating)
 
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: -1}})
+    //  state = events.append(state, {author: 'alice', sequence: 4, content: {}})
+    //  t.deepEqual(state.peers.bob.notes, {bob: note(2, true), alice: note(4, false)})
+    t.end()
+  })
 
-  t.deepEqual(state.peers.bob.clock, {alice: -1})
-  t.deepEqual(state.peers.bob.notes, {})
+  test('note when value is not integer', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {}
+    }
 
-  t.end()
-})
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: {} })
 
-test('notes can be passed inside {clock:{}} object', function (t) {
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: {alice: true}, blocks: {},
-    peers: {}
-  }
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: -1}})
+    t.deepEqual(state.peers.bob.clock, {})
+    state = events.notes(state, { id: 'bob', value: { alice: true } })
 
-  state = events.notes(state, {id: 'bob', value: {
-    clock: {bob: note(4, true)}
-  }})
+    t.deepEqual(state.peers.bob.clock, { alice: -1 })
+    t.deepEqual(state.peers.bob.notes, { alice: note(3, true), bob: note(2, true) })
 
-  t.equal(state.peers.bob.clock.bob, 4)
-  t.end()
-})
+    t.end()
+  })
 
-test('test if timeout happens while loading', function (t) {
+  test('test sends empty clock if nothing needed', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {}
+    }
 
-  var state = {
-    clock: { alice: 3, bob: 2},
-    follows: {alice: true,  bob: true}, blocks: {},
-    peers: {},
-    timeout: 1
-  }
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 3, bob: 2 } })
 
-  state = events.connect(state, {id: 'bob', ts: 1, client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: note(0, true), bob: note(0, true)}})
+    t.deepEqual(state.peers.bob.clock, { alice: 3, bob: 2 })
+    t.deepEqual(state.peers.bob.notes, {})
 
-  state = events.connect(state, {id: 'charles', ts: 2, client: false})
-  console.log(state)
-  state = events.timeout(state, {ts: 4})
+    // receive empty clock
+    state = events.notes(state, { id: 'bob', value: {} })
+    t.deepEqual(state.peers.bob.replicating, {})
 
-  t.end()
-})
+    t.end()
+  })
 
+  test('connects in sync then another message', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {}
+    }
 
-test('test blocks while connected', function (t) {
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 3, bob: 2 } })
 
-  var state = {
-    id: 'alice', //we are alice
-    clock: { alice: 3, bob: 2},
-    follows: {alice: true,  bob: true}, blocks: {},
-    peers: {},
-    timeout: 1
-  }
+    t.deepEqual(state.peers.bob.clock, { alice: 3, bob: 2 })
+    t.deepEqual(state.peers.bob.notes, {})
 
-  state = events.connect(state, {id: 'bob', ts: 1, client: false})
-  state = events.peerClock(state, {id: 'bob', value:{alice: note(0, true), bob: note(0, true)}})
+    // receive empty clock
+    state = events.notes(state, { id: 'bob', value: {} })
+    t.deepEqual(state.peers.bob.replicating, {})
 
-  //charles blocks bob
-  state = events.block(state, {id: 'charles', target: 'bob', value: true})
-  t.deepEqual(state.blocks, {charles: {bob: true}})
-  t.notOk(state.peers.bob.blocked)
-  state = events.block(state, {id: 'alice', target: 'bob', value: true})
-  t.deepEqual(state.blocks, {charles: {bob: true}, alice: {bob: true}})
-  t.equal(state.peers.bob.blocked, true)
+    state = events.append(state, { author: 'alice', sequence: 4, content: {} })
+    t.deepEqual(state.peers.bob.notes, { alice: note(4, false) })
 
-  state = events.timeout(state, {ts: 4})
+    t.end()
+  })
 
-  t.end()
-})
+  test('unfollow', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: {},
+      blocks: {},
+      peers: {}
+    }
 
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: {} })
 
+    t.deepEqual(state.peers.bob.clock, {})
+    t.deepEqual(state.peers.bob.notes, { })
+    state = events.notes(state, { id: 'bob', value: { alice: note(3, true), bob: note(2, true) } })
+    t.deepEqual(state.peers.bob.notes, { alice: note(-1, true), bob: note(-1, true) })
+
+    state.peers.bob.notes = null
+
+    state = events.follow(state, { id: 'alice', value: false })
+
+    t.deepEqual(state.peers.bob.notes, null)
+
+    state = events.notes(state, { id: 'bob', value: { charles: note(-1, true) } })
+    t.deepEqual(state.peers.bob.notes, { charles: note(-1, true) })
+    state.peers.bob.notes = null
+    state = events.notes(state, { id: 'bob', value: { charles: note(-1, true) } })
+    t.deepEqual(state.peers.bob.notes, null)
+
+    t.end()
+  })
+
+  test('remember clock of unfollow', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true },
+      blocks: {},
+      peers: {}
+    }
+
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: -1 } })
+
+    t.deepEqual(state.peers.bob.clock, { alice: -1 })
+    t.deepEqual(state.peers.bob.notes, {})
+
+    t.end()
+  })
+
+  test('notes can be passed inside {clock:{}} object', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true },
+      blocks: {},
+      peers: {}
+    }
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: -1 } })
+
+    state = events.notes(state, {
+      id: 'bob',
+      value: {
+        clock: { bob: note(4, true) }
+      }
+    })
+
+    t.equal(state.peers.bob.clock.bob, 4)
+    t.end()
+  })
+
+  test('test if timeout happens while loading', function (t) {
+    let state = {
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {},
+      timeout: 1
+    }
+
+    state = events.connect(state, { id: 'bob', ts: 1, client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: note(0, true), bob: note(0, true) } })
+
+    state = events.connect(state, { id: 'charles', ts: 2, client: false })
+    console.log(state)
+    state = events.timeout(state, { ts: 4 })
+
+    t.end()
+  })
+
+  test('test blocks while connected', function (t) {
+    let state = {
+      id: 'alice', // we are alice
+      clock: { alice: 3, bob: 2 },
+      follows: { alice: true, bob: true },
+      blocks: {},
+      peers: {},
+      timeout: 1
+    }
+
+    state = events.connect(state, { id: 'bob', ts: 1, client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: note(0, true), bob: note(0, true) } })
+
+    // charles blocks bob
+    state = events.block(state, { id: 'charles', target: 'bob', value: true })
+    t.deepEqual(state.blocks, { charles: { bob: true } })
+    t.notOk(state.peers.bob.blocked)
+    state = events.block(state, { id: 'alice', target: 'bob', value: true })
+    t.deepEqual(state.blocks, { charles: { bob: true }, alice: { bob: true } })
+    t.equal(state.peers.bob.blocked, true)
+
+    state = events.timeout(state, { ts: 4 })
+
+    t.end()
+  })
 }
 
-if(!module.parent)
-  module.exports(require('./options'))
+if (!module.parent) { module.exports(require('./options')) }

--- a/test/live-stall.js
+++ b/test/live-stall.js
@@ -1,26 +1,27 @@
 
-var createSimulator = require('./simulator')
-var _events = require('../events')(require('./options'))
-var test = require('tape')
-var progress = require('../progress')
-var events = {}
-for(var k in _events) (function (fn, k) {
-  events[k] = function (state, ev) {
-    if(state.stalled) return state
-    return fn(state, ev)
-  }
-})(_events[k], k)
-
+const createSimulator = require('./simulator')
+const _events = require('../events')(require('./options'))
+const test = require('tape')
+const progress = require('../progress')
+const events = {}
+for (const k in _events) {
+  (function (fn, k) {
+    events[k] = function (state, ev) {
+      if (state.stalled) return state
+      return fn(state, ev)
+    }
+  })(_events[k], k)
+}
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var carl = network['carl'] = tick.createPeer('carl')
-    var dawn = network['dawn'] = tick.createPeer('dawn')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const carl = network.carl = tick.createPeer('carl')
+    const dawn = network.dawn = tick.createPeer('dawn')
 
     alice.state.timeout = bob.state.timeout = dawn.state.timeout = 2
     alice.init({})
@@ -28,10 +29,10 @@ function createTest (seed, log) {
     carl.init({})
     dawn.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
-    bob.append({author: 'bob', sequence: 1, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
+    bob.append({ author: 'bob', sequence: 1, content: {} })
 
     alice.follow('alice')
     alice.follow('bob')
@@ -50,7 +51,7 @@ function createTest (seed, log) {
 
     tick.run(network)
     carl.state.stalled = true
-    alice.append({author: 'alice', sequence: 4, content: {}})
+    alice.append({ author: 'alice', sequence: 4, content: {} })
 
     tick.run(network)
 
@@ -58,8 +59,8 @@ function createTest (seed, log) {
     t.deepEqual(bob.store, alice.store, 'bob matches alice')
 
     function isComplete (peer, name) {
-      var prog = progress(peer.state)
-      t.equal(prog.current, prog.target, name +' is complete')
+      const prog = progress(peer.state)
+      t.equal(prog.current, prog.target, name + ' is complete')
     }
 
     isComplete(alice, 'alice')
@@ -70,12 +71,5 @@ function createTest (seed, log) {
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++) createTest(i)
-else createTest(+seed, true)
-
-
-
-
-
+const seed = process.argv[2]
+if (isNaN(seed)) { for (let i = 0; i < 100; i++) createTest(i) } else createTest(+seed, true)

--- a/test/loop.js
+++ b/test/loop.js
@@ -1,25 +1,25 @@
 
-var createSimulator = require('./simulator')
-var options = require('./options')
+const createSimulator = require('./simulator')
+const options = require('./options')
 
-var test = require('tape')
+const test = require('tape')
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var charles = network['charles'] = tick.createPeer('charles')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const charles = network.charles = tick.createPeer('charles')
 
     alice.init({})
     bob.init({})
     charles.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
 
     alice.follow('alice')
     bob.follow('alice')
@@ -29,33 +29,20 @@ function createTest (seed, log) {
     alice.connect(charles)
     bob.connect(charles)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, alice.store, 'charles<->alice')
 
-    if(log) tick.log()
+    if (log) tick.log()
 
     t.end()
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++)
-    createTest(i)
-else
-  createTest(+seed, true)
-
-
-
-
-
-
-
-
-
-
-
+const seed = process.argv[2]
+if (isNaN(seed)) {
+  for (let i = 0; i < 100; i++) { createTest(i) }
+} else { createTest(+seed, true) }

--- a/test/lost-state.js
+++ b/test/lost-state.js
@@ -1,7 +1,7 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
-var test = require('tape')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
+const test = require('tape')
 
 function count (output) {
   return output.reduce(function (a, b) {
@@ -11,33 +11,32 @@ function count (output) {
 
 function flatten (output) {
   return output.reduce(function (a, b) {
-    if(b.msg) return a
-    for(var k in b.value)
-      a[b.from][k] = options.getSequence(b.value[k])
+    if (b.msg) return a
+    for (const k in b.value) { a[b.from][k] = options.getSequence(b.value[k]) }
     return a
-  }, {alice: {}, bob: {}})
+  }, { alice: {}, bob: {} })
 }
 
 function isComplete (peer, name, t) {
-  var prog = progress(peer.state)
-  t.equal(prog.current, prog.target, name +' is complete')
+  const prog = progress(peer.state)
+  t.equal(prog.current, prog.target, name + ' is complete')
 }
 
 test('loose local state', function (t) {
-  var tick = createSimulator(0, true, options)
+  const tick = createSimulator(0, true, options)
 
-  var network = {}
-  var alice = network['alice'] = tick.createPeer('alice')
-  var bob = network['bob'] = tick.createPeer('bob')
+  const network = {}
+  const alice = network.alice = tick.createPeer('alice')
+  let bob = network.bob = tick.createPeer('bob')
 
   alice.init({})
   bob.init({})
 
-  alice.append({author: 'alice', sequence: 1, content: {}})
-  alice.append({author: 'alice', sequence: 2, content: {}})
-  alice.append({author: 'alice', sequence: 3, content: {}})
-  bob.append({author: 'bob', sequence: 1, content: {}})
-  bob.append({author: 'bob', sequence: 2, content: {}})
+  alice.append({ author: 'alice', sequence: 1, content: {} })
+  alice.append({ author: 'alice', sequence: 2, content: {} })
+  alice.append({ author: 'alice', sequence: 3, content: {} })
+  bob.append({ author: 'bob', sequence: 1, content: {} })
+  bob.append({ author: 'bob', sequence: 2, content: {} })
 
   alice.follow('bob')
   alice.follow('alice')
@@ -46,12 +45,12 @@ test('loose local state', function (t) {
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   alice.disconnect(bob)
 
-  //should have set up peer.replicatings to tx/rx alice
-  t.deepEqual(flatten(tick.output), {alice: {alice: 3, bob: 0}, bob: {alice: 0, bob: 2}})
+  // should have set up peer.replicatings to tx/rx alice
+  t.deepEqual(flatten(tick.output), { alice: { alice: 3, bob: 0 }, bob: { alice: 0, bob: 2 } })
   t.equal(count(tick.output), 2)
 
   t.deepEqual(bob.store, alice.store)
@@ -59,10 +58,10 @@ test('loose local state', function (t) {
   isComplete(alice, 'alice', t)
   isComplete(bob, 'bob', t)
 
-  console.log("===========START OVER===========")
+  console.log('===========START OVER===========')
 
   // bob gets a brick in his head and forgets everything
-  bob = network['bob'] = tick.createPeer('bob')
+  bob = network.bob = tick.createPeer('bob')
   bob.init({})
   t.deepEqual(bob.store, {})
 
@@ -70,14 +69,14 @@ test('loose local state', function (t) {
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
-  console.log("===========SECOND ROUND===========")
+  console.log('===========SECOND ROUND===========')
 
   // simulate a contact message received in bobs feed
   bob.follow('alice')
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   t.deepEqual(bob.store, alice.store)
 
@@ -86,26 +85,26 @@ test('loose local state', function (t) {
 
   alice.disconnect(bob)
 
-  console.log("===========START OVER 2===========")
+  console.log('===========START OVER 2===========')
 
   // bob gets a brick in his head and restores from backup
-  bob = network['bob'] = tick.createPeer('bob')
+  bob = network.bob = tick.createPeer('bob')
   bob.init({})
 
-  bob.append({author: 'bob', sequence: 1, content: {}})
+  bob.append({ author: 'bob', sequence: 1, content: {} })
 
   bob.follow('bob')
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
-  console.log("===========SECOND ROUND===========")
+  console.log('===========SECOND ROUND===========')
 
   // simulate a contact message received in bobs feed
   bob.follow('alice')
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   t.deepEqual(bob.store, alice.store)
 

--- a/test/multiple.js
+++ b/test/multiple.js
@@ -1,55 +1,56 @@
+/* eslint-disable camelcase */
 
-var test = require('tape')
+const test = require('tape')
 
 module.exports = function (events) {
+  const note = events.note
 
-var note = events.note
+  test('if connects to multiple peers, should replicate a feed from only one', function (t) {
+    let state = events.initialize('alice')
+    state.follows = {
+      alice: true, bob: true, charles: true
+    }
+    state = events.clock(state, { alice: 3, bob: 2, charles: 5 })
 
-test('if connects to multiple peers, should replicate a feed from only one', function (t) {
+    state = events.connect(state, { id: 'bob', client: false })
+    state = events.peerClock(state, { id: 'bob', value: { alice: 2, bob: 2, charles: 5 } })
+    state = events.connect(state, { id: 'charles', client: false })
+    state = events.peerClock(state, { id: 'charles', value: { alice: 2, bob: 2, charles: 5 } })
 
-  var state = events.initialize('alice')
-  state.follows = {
-    alice: true, bob: true, charles: true
-  }
-  state = events.clock(state, {alice: 3, bob: 2, charles: 5})
-  
-  state = events.connect(state, {id: 'bob', client: false})
-  state = events.peerClock(state, {id: 'bob', value: {alice: 2, bob: 2, charles: 5}})
-  state = events.connect(state, {id: 'charles', client: false})
-  state = events.peerClock(state, {id: 'charles', value: {alice: 2, bob: 2, charles: 5}})
+    console.log(state.peers)
 
-  console.log(state.peers)
+    state = events.notes(state, {
+      id: 'bob',
+      value: {
+        alice: note(3, true), bob: note(5, true), charles: note(9, true)
+      }
+    })
+    state = events.notes(state, {
+      id: 'charles',
+      value: {
+        alice: note(3, true), bob: note(4, true), charles: note(9, true)
+      }
+    })
+    console.log(state.peers)
 
-  state = events.notes(state, {id: 'bob', value: {
-    alice: note(3, true), bob: note(5, true), charles: note(9, true)
-  }})
-  state = events.notes(state, {id: 'charles', value: {
-    alice: note(3, true), bob: note(4, true), charles: note(9, true)
-  }})
-  console.log(state.peers)
-
-  //we should only request transmissions from at most one peer.
-  var notes = {}
-  for(var peer_id in state.peers) {
-    var peer = state.peers[peer_id]
-    for(var feed_id in peer.notes) {
-      t.equal(events.getReceive(peer.notes[feed_id]), peer.replicating[feed_id].rx, 'implied rx state should be recorded, seq:'+peer.notes[feed_id]+', rx='+peer.replicating[feed_id].rx)
-      if(events.getReceive(peer.notes[feed_id])) {
-        notes[feed_id] = (notes[feed_id] || 0) + 1
+    // we should only request transmissions from at most one peer.
+    const notes = {}
+    for (const peer_id in state.peers) {
+      const peer = state.peers[peer_id]
+      for (const feed_id in peer.notes) {
+        t.equal(events.getReceive(peer.notes[feed_id]), peer.replicating[feed_id].rx, 'implied rx state should be recorded, seq:' + peer.notes[feed_id] + ', rx=' + peer.replicating[feed_id].rx)
+        if (events.getReceive(peer.notes[feed_id])) {
+          notes[feed_id] = (notes[feed_id] || 0) + 1
+        }
       }
     }
-  }
 
-  console.log(JSON.stringify(state.peers, null, 2))
+    console.log(JSON.stringify(state.peers, null, 2))
 
-  t.deepEqual(notes, {alice: 1, bob: 1, charles: 1})
+    t.deepEqual(notes, { alice: 1, bob: 1, charles: 1 })
 
-  t.end()
-})
-
+    t.end()
+  })
 }
 
-if(!module.parent)
-  module.exports(require('./options'))
-
-
+if (!module.parent) { module.exports(require('./options')) }

--- a/test/partial.js
+++ b/test/partial.js
@@ -1,26 +1,26 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
+const createSimulator = require('./simulator')
+const options = require('./options')
 
-var test = require('tape')
+const test = require('tape')
 
 test('partial replication', function (t) {
-  var tick = createSimulator(0, true, options)
+  const tick = createSimulator(0, true, options)
 
-  var network = {}
-  var alice = network['alice'] = tick.createPeer('alice')
-  var bob = network['bob'] = tick.createPeer('bob')
-  var charlie = network['charlie'] = tick.createPeer('charlie')
+  const network = {}
+  const alice = network.alice = tick.createPeer('alice')
+  const bob = network.bob = tick.createPeer('bob')
+  const charlie = network.charlie = tick.createPeer('charlie')
 
   alice.init({})
   bob.init({})
   charlie.init({})
 
-  alice.append({author: 'alice', sequence: 1, content: {}})
-  alice.append({author: 'alice', sequence: 2, content: {}})
-  alice.append({author: 'alice', sequence: 3, content: {}})
+  alice.append({ author: 'alice', sequence: 1, content: {} })
+  alice.append({ author: 'alice', sequence: 2, content: {} })
+  alice.append({ author: 'alice', sequence: 3, content: {} })
 
-  //alice.store['alice'] = alice.store['alice'].slice(1)
-  
+  // alice.store['alice'] = alice.store['alice'].slice(1)
+
   alice.follow('alice')
   bob.follow('alice')
 
@@ -30,7 +30,7 @@ test('partial replication', function (t) {
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   // alice sends her whole feed to bob
   t.deepEqual(bob.store, alice.store)
@@ -38,21 +38,21 @@ test('partial replication', function (t) {
   alice.disconnect(bob)
 
   // lets assume that instead bob had done a partial replication with alice
-  bob.store['alice'] = bob.store['alice'].slice(1)
+  bob.store.alice = bob.store.alice.slice(1)
 
   bob.connect(charlie)
-  
-  while(tick(network)) ;
+
+  while (tick(network)) ;
 
   // charlie is not able to get alices feed from bob
   t.deepEqual({}, charlie.store)
 
   charlie.connect(alice)
-  
-  while(tick(network)) ;
+
+  while (tick(network)) ;
 
   // charlie should now have alices feed
   t.deepEqual(alice.store, charlie.store)
-  
+
   t.end()
 })

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -1,7 +1,7 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
-var test = require('tape')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
+const test = require('tape')
 
 function count (output) {
   return output.reduce(function (a, b) {
@@ -11,28 +11,27 @@ function count (output) {
 
 function flatten (output) {
   return output.reduce(function (a, b) {
-    if(b.msg) return a
-    for(var k in b.value)
-      a[b.from][k] = options.getSequence(b.value[k])
+    if (b.msg) return a
+    for (const k in b.value) { a[b.from][k] = options.getSequence(b.value[k]) }
     return a
-  }, {alice: {}, bob: {}})
+  }, { alice: {}, bob: {} })
 }
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
 
     alice.init({})
     bob.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
-    bob.append({author: 'bob', sequence: 1, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
+    bob.append({ author: 'bob', sequence: 1, content: {} })
 
     alice.follow('alice')
     alice.follow('bob')
@@ -41,40 +40,39 @@ function createTest (seed, log) {
 
     alice.connect(bob)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     alice.disconnect(bob)
-    //should have set up peer.replicatings to tx/rx alice
-    t.deepEqual(flatten(tick.output), {alice: {alice: 3, bob: 0}, bob: {alice: 0, bob: 1}})
+    // should have set up peer.replicatings to tx/rx alice
+    t.deepEqual(flatten(tick.output), { alice: { alice: 3, bob: 0 }, bob: { alice: 0, bob: 1 } })
     t.equal(count(tick.output), 2)
-    bob.append({author: 'bob', sequence: 2, content: {}})
+    bob.append({ author: 'bob', sequence: 2, content: {} })
 
     console.log('1', tick.output)
     tick.output.splice(0, tick.output.length)
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     console.log('2', tick.output)
     tick.output.splice(0, tick.output.length)
     alice.connect(bob)
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     console.log('3', tick.output)
-    t.deepEqual(flatten(tick.output), {alice: {alice: 3, bob: 1}, bob: {alice: 3, bob: 2}})
+    t.deepEqual(flatten(tick.output), { alice: { alice: 3, bob: 1 }, bob: { alice: 3, bob: 2 } })
     t.equal(count(tick.output), 3)
     tick.output.splice(0, tick.output.length)
 
     alice.disconnect(bob)
     alice.connect(bob)
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     t.deepEqual(bob.store, alice.store)
     console.log('4', tick.output)
     tick.output.splice(0, tick.output.length)
 
-
     function isComplete (peer, name) {
-      var prog = progress(peer.state)
-      t.equal(prog.current, prog.target, name +' is complete')
+      const prog = progress(peer.state)
+      t.equal(prog.current, prog.target, name + ' is complete')
     }
 
     isComplete(alice, 'alice')
@@ -84,10 +82,5 @@ function createTest (seed, log) {
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++) createTest(i)
-else createTest(+seed, true)
-
-
-
+const seed = process.argv[2]
+if (isNaN(seed)) { for (let i = 0; i < 100; i++) createTest(i) } else createTest(+seed, true)

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,40 +1,38 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
+const createSimulator = require('./simulator')
+const options = require('./options')
 
-var test = require('tape')
+const test = require('tape')
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
 
     alice.init({})
     bob.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
 
     alice.follow('alice')
     bob.follow('alice')
 
     alice.connect(bob)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
     t.deepEqual(bob.store, alice.store)
     t.end()
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++)
-    createTest(i)
-else
-  createTest(+seed, true)
+const seed = process.argv[2]
+if (isNaN(seed)) {
+  for (let i = 0; i < 100; i++) { createTest(i) }
+} else { createTest(+seed, true) }

--- a/test/simulator.js
+++ b/test/simulator.js
@@ -1,62 +1,64 @@
-var RNG = require('rng')
+/* eslint-disable camelcase */
+const RNG = require('rng')
 
-var log
+let log
 
 module.exports = function (seed, _log, _events) {
-  if(!_events) _events = require('../events')(require('../v3'))
+  if (!_events) _events = require('../events')(require('../v3'))
   log = _log
-  var rng = new RNG.MT(seed || 0)
+  const rng = new RNG.MT(seed || 0)
 
-  var events = {}
+  const events = {}
 
-  for(var k in _events) (function (fn, k) {
-    events[k] = function (state, value) {
-      if(log) console.log(k.toUpperCase()+'('+state.id+')', value)
-      return fn(state, value)
-    }
-  })(_events[k],k)
+  for (const k in _events) {
+    (function (fn, k) {
+      events[k] = function (state, value) {
+        if (log) console.log(k.toUpperCase() + '(' + state.id + ')', value)
+        return fn(state, value)
+      }
+    })(_events[k], k)
+  }
 
-  var output = []
-  var ts = 0
+  const output = []
+  let ts = 0
 
-  function createPeer(id, validate) {
+  function createPeer (id, validate) {
     validate = validate || function () {}
-    var store = {}, state = events.initialize(id), self
-    var ts = 0
-    var pClock = {}
+    let store = {}; let state = events.initialize(id); let self
+    let ts = 0
+    const pClock = {}
     return self = {
-      id: id,
+      id,
       clocks: pClock,
-      store: store,
-      state: state,
+      store,
+      state,
       retriving: [],
       init: function (_store) {
         self.store = store = _store
-        var clock = {}
-        for(var k in store)
-          clock[k] = store[k].length
+        const clock = {}
+        for (const k in store) { clock[k] = store[k].length }
         state = events.clock(state, clock)
       },
       connect: function (other) {
-        state = events.connect(state, {id: other.id, ts: ++ts, client: true})
-        state = events.peerClock(state, {id: other.id, value: pClock[other.id] || {}, ts: ++ts})
-        other.state = events.connect(other.state, {id: this.id, ts: ++ts, client: false})
-        other.state = events.peerClock(other.state, {id: id, value: other.clocks[id] || {}, ts: ++ts})
+        state = events.connect(state, { id: other.id, ts: ++ts, client: true })
+        state = events.peerClock(state, { id: other.id, value: pClock[other.id] || {}, ts: ++ts })
+        other.state = events.connect(other.state, { id: this.id, ts: ++ts, client: false })
+        other.state = events.peerClock(other.state, { id, value: other.clocks[id] || {}, ts: ++ts })
       },
       disconnect: function (other) {
         pClock[other.id] = state.peers[other.id].clock
         other.clocks[id] = other.state.peers[id].clock
 
-        state = events.disconnect(state, {id: other.id, ts: ++ts})
-        other.state = events.disconnect(other.state, {id: this.id, ts: ++ts})
+        state = events.disconnect(state, { id: other.id, ts: ++ts })
+        other.state = events.disconnect(other.state, { id: this.id, ts: ++ts })
       },
       follow: function (peer, value) {
-        state = events.follow(state, {id: peer, value: value !== false, ts: ++ts})
+        state = events.follow(state, { id: peer, value: value !== false, ts: ++ts })
       },
       append: function (msg) {
-        var ary = store[msg.author] = store[msg.author] || []
-        if(msg.sequence === ary.length + 1) {
-          validate (store[msg.author], msg)
+        const ary = store[msg.author] = store[msg.author] || []
+        if (msg.sequence === ary.length + 1) {
+          validate(store[msg.author], msg)
           ary.push(msg)
           state = events.append(state, msg)
         }
@@ -65,62 +67,61 @@ module.exports = function (seed, _log, _events) {
   }
 
   function shuffle (ary) {
-    for(var i = 0; i < ary.length; i++) {
-      var j = ~~(rng.random()*ary.length)
-      var tmp = ary[i]
+    for (let i = 0; i < ary.length; i++) {
+      const j = ~~(rng.random() * ary.length)
+      const tmp = ary[i]
       ary[i] = ary[j]
       ary[j] = tmp
     }
     return ary
   }
 
-  function randomFind(obj, iter) {
-    if(!iter) iter = function (key, fn) { return fn() }
-    if(!obj) throw new Error('obj not provided')
+  function randomFind (obj, iter) {
+    if (!iter) iter = function (key, fn) { return fn() }
+    if (!obj) throw new Error('obj not provided')
 
-    var keys = shuffle(Object.keys(obj))
-    for(var i = 0; i < keys.length; i++)
-      if(iter(keys[i], obj[keys[i]])) return true
+    const keys = shuffle(Object.keys(obj))
+    for (let i = 0; i < keys.length; i++) { if (iter(keys[i], obj[keys[i]])) return true }
 
     return false
   }
 
   function tick (network) {
     return randomFind(network, function (id, peer) {
-      //database ops
-      if(peer.state.stalled) return
+      // database ops
+      if (peer.state.stalled) return
       return randomFind([function () {
-        //append(receive), retrive, retrive_cb
+        // append(receive), retrive, retrive_cb
         return randomFind([function () {
           return randomFind(peer.state.peers, function (key, p2p) {
-            if(!p2p.clock) {
-              peer.state = events.peerClock(peer.state, {id: key, value: {}, ts: ++ts})
+            if (!p2p.clock) {
+              peer.state = events.peerClock(peer.state, { id: key, value: {}, ts: ++ts })
               return true
             }
           })
         }, function () {
-          if(peer.state.receive.length) {
-            var ev = peer.state.receive.shift()
+          if (peer.state.receive.length) {
+            const ev = peer.state.receive.shift()
             try {
               peer.append(ev.value)
             } catch (err) {
-              return peer.state = events.block(peer.state, {id: ev.value.author, target: ev.id, value: true})
+              return peer.state = events.block(peer.state, { id: ev.value.author, target: ev.id, value: true })
             }
             return true
           }
         }, function () {
           return randomFind(peer.state.peers, function (key, p2p) {
-            //randomly order, to simulate async
+            // randomly order, to simulate async
             p2p.retrive = shuffle(p2p.retrive)
-            if(p2p.retrive.length) {
-              var peer_id = p2p.retrive.shift()
-              //it's possible that two peers need to retrive the same message at the same time
-              //this may mean that the retrival is queued twice.
-              var rep = p2p.replicating[peer_id]
-              if(rep.tx && rep.sent < peer.state.clock[peer_id]) {
-                var msg = peer.store[peer_id][rep.sent]
-                if(msg == null) {
-                  throw new Error('null msg!, clock:'+peer.state.clock[peer_id]+ ', id:'+peer_id)
+            if (p2p.retrive.length) {
+              const peer_id = p2p.retrive.shift()
+              // it's possible that two peers need to retrive the same message at the same time
+              // this may mean that the retrival is queued twice.
+              const rep = p2p.replicating[peer_id]
+              if (rep.tx && rep.sent < peer.state.clock[peer_id]) {
+                const msg = peer.store[peer_id][rep.sent]
+                if (msg == null) {
+                  throw new Error('null msg!, clock:' + peer.state.clock[peer_id] + ', id:' + peer_id)
                 }
                 peer.retriving.push(msg)
               }
@@ -128,32 +129,31 @@ module.exports = function (seed, _log, _events) {
             }
           })
         }, function () {
-          if(peer.retriving.length) {
+          if (peer.retriving.length) {
             peer.retriving = shuffle(peer.retriving)
             peer.state = events.retrive(peer.state, peer.retriving.shift())
             return true
           }
         }])
-      }, function () { //network ops
+      }, function () { // network ops
         return randomFind(peer.state.peers, function (remote_id, remote) {
-          if(remote.notes) {
-            var notes = remote.notes
+          if (remote.notes) {
+            const notes = remote.notes
             remote.notes = null
             network[remote_id].state =
-              events.notes(network[remote_id].state, {id: id, value: notes, ts: ++ts})
-            output.push({from: id, to: remote_id, value: notes, msg: false})
+              events.notes(network[remote_id].state, { id, value: notes, ts: ++ts })
+            output.push({ from: id, to: remote_id, value: notes, msg: false })
             return true
-          }
-          else if(remote.msgs.length) {
-            output.push({from: id, to: remote_id, value: remote.msgs[0], msg: true})
+          } else if (remote.msgs.length) {
+            output.push({ from: id, to: remote_id, value: remote.msgs[0], msg: true })
             network[remote_id].state =
-              events.receive(network[remote_id].state, {id: id, value: remote.msgs.shift(), ts: ++ts})
+              events.receive(network[remote_id].state, { id, value: remote.msgs.shift(), ts: ++ts })
             return true
           }
         })
       }])
     })
-    //TODO: test random network connections.
+    // TODO: test random network connections.
   }
 
   tick.createPeer = createPeer
@@ -162,27 +162,23 @@ module.exports = function (seed, _log, _events) {
   tick.log = function () {
     console.log(
       tick.output.map(function (e) {
-        if(e.msg)
-          return e.from+'>'+e.to+':'+e.value.author[0]+e.value.sequence
-        else
-          return e.from+'>'+e.to+':'+JSON.stringify(e.value)
+        if (e.msg) { return e.from + '>' + e.to + ':' + e.value.author[0] + e.value.sequence } else { return e.from + '>' + e.to + ':' + JSON.stringify(e.value) }
       }).join('\n')
     )
   }
 
   tick.ts = function (_ts) {
-    return ts += (_ts|0)
+    return ts += (_ts | 0)
   }
 
   tick.run = function (network) {
-    var loop = 1, first = true
-    while(loop) {
+    let loop = 1; let first = true
+    while (loop) {
       loop = 0
-      while(tick(network)) loop ++
-      if(loop || first) {
-        for(var k in network)
-          network[k].state = events.timeout(network[k].state, {ts: ts++})
-        if(first) loop = 1
+      while (tick(network)) loop++
+      if (loop || first) {
+        for (const k in network) { network[k].state = events.timeout(network[k].state, { ts: ts++ }) }
+        if (first) loop = 1
         first = false
       }
     }
@@ -190,6 +186,3 @@ module.exports = function (seed, _log, _events) {
 
   return tick
 }
-
-
-

--- a/test/stall.js
+++ b/test/stall.js
@@ -1,26 +1,27 @@
 
-var createSimulator = require('./simulator')
-var _events = require('../events')(require('./options'))
-var test = require('tape')
+const createSimulator = require('./simulator')
+const _events = require('../events')(require('./options'))
+const test = require('tape')
 
-var events = {}
-for(var k in _events) (function (fn, k) {
-  events[k] = function (state, ev) {
-    if(state.stalled) return state
-    return fn(state, ev)
-  }
-})(_events[k], k)
-
+const events = {}
+for (const k in _events) {
+  (function (fn, k) {
+    events[k] = function (state, ev) {
+      if (state.stalled) return state
+      return fn(state, ev)
+    }
+  })(_events[k], k)
+}
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, events)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, events)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var carl = network['carl'] = tick.createPeer('carl')
-    var dawn = network['dawn'] = tick.createPeer('dawn')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const carl = network.carl = tick.createPeer('carl')
+    const dawn = network.dawn = tick.createPeer('dawn')
 
     alice.state.timeout = bob.state.timeout = dawn.state.timeout = 1
     alice.init({})
@@ -28,14 +29,14 @@ function createTest (seed, log) {
     carl.init({})
     dawn.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    bob.append({author: 'alice', sequence: 1, content: {}})
-    carl.append({author: 'alice', sequence: 1, content: {}})
-    dawn.append({author: 'alice', sequence: 1, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    bob.append({ author: 'alice', sequence: 1, content: {} })
+    carl.append({ author: 'alice', sequence: 1, content: {} })
+    dawn.append({ author: 'alice', sequence: 1, content: {} })
 
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
-    bob.append({author: 'bob', sequence: 1, content: {}})
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
+    bob.append({ author: 'bob', sequence: 1, content: {} })
 
     alice.follow('alice')
     alice.follow('bob')
@@ -53,38 +54,37 @@ function createTest (seed, log) {
     alice.connect(bob)
     dawn.connect(bob)
 
-    while((
+    while ((
       (!dawn.store.alice || dawn.store.alice.length < 2)
-//      &&
-//      (!bob.store.alice || bob.store.alice.length < 2)
+    //      &&
+    //      (!bob.store.alice || bob.store.alice.length < 2)
     ) && tick(network))
       ;
 
-
     carl.state.stalled = true
-//    bob.state.peers.alice.replicating.alice.rx = false
-//    dawn.state.peers.bob.replicating.alice.rx = false
-//    bob.state.peers.carl.replicating.alice.rx = true
-//    dawn.state.peers.carl.replicating.alice.rx = true
+    //    bob.state.peers.alice.replicating.alice.rx = false
+    //    dawn.state.peers.bob.replicating.alice.rx = false
+    //    bob.state.peers.carl.replicating.alice.rx = true
+    //    dawn.state.peers.carl.replicating.alice.rx = true
 
-//    bob.state.peers.alice.notes = null
-//    dawn.state.peers.bob.notes = null
+    //    bob.state.peers.alice.notes = null
+    //    dawn.state.peers.bob.notes = null
 
-    //then continue running the simulation, including timeout
+    // then continue running the simulation, including timeout
     tick.log()
     tick.output.splice(0, tick.output.length)
     console.log(JSON.stringify(bob.state, null, 2))
     console.log(JSON.stringify(dawn.state, null, 2))
-//    console.log(tick.ts())
-//    console.log("CONTINUE")
-//    return t.end()
+    //    console.log(tick.ts())
+    //    console.log("CONTINUE")
+    //    return t.end()
     tick.run(network)
 
-  //    while(tick(network));
+    //    while(tick(network));
 
     tick.log()
 
-//    return t.end()
+    //    return t.end()
 
     t.deepEqual(dawn.store, alice.store, 'dawn matches alice')
     t.deepEqual(bob.store, alice.store, 'bob matches alice')
@@ -93,12 +93,5 @@ function createTest (seed, log) {
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed))
-  for(var i = 0; i < 100; i++) createTest(i)
-else createTest(+seed, true)
-
-
-
-
-
+const seed = process.argv[2]
+if (isNaN(seed)) { for (let i = 0; i < 100; i++) createTest(i) } else createTest(+seed, true)

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,31 +1,29 @@
-var createPeer = require('../')
-var test = require('tape')
+const createPeer = require('../')
+const test = require('tape')
 
 function create (id) {
-  var store = {}
+  const store = {}
 
   function append (msg, cb) {
     store[msg.author] = store[msg.author] || []
-    if(msg.sequence - 1 != store[msg.author].length)
-      cb(new Error('out of order'))
-    else {
+    if (msg.sequence - 1 !== store[msg.author].length) { cb(new Error('out of order')) } else {
       store[msg.author].push(msg)
       p.onAppend(msg)
       cb(null, msg)
     }
   }
 
-  var p = createPeer({
-    id: id,
+  const p = createPeer({
+    id,
     getClock: function (id, cb) {
       cb(null, {})
     },
     setClock: function () {},
     getAt: function (pair, cb) {
-      if(!store[pair.id] || !store[pair.id][pair.sequence]) cb(new Error('not found'))
+      if (!store[pair.id] || !store[pair.id][pair.sequence]) cb(new Error('not found'))
       else cb(null, store[pair.id][pair.sequence])
     },
-    append: append
+    append
   })
   p.store = store
   p.append = append
@@ -33,76 +31,70 @@ function create (id) {
 }
 
 test('a<->b', function (t) {
-
-  var alice = create('alice')
-  var bob = create('bob')
+  const alice = create('alice')
+  const bob = create('bob')
 
   alice.request('alice', true)
   alice.request('bob', true)
   bob.request('alice', true)
   bob.request('bob', true)
 
-  var as = alice.createStream('bob', 3, false)
-  var bs = bob.createStream('alice', 3, true)
+  const as = alice.createStream('bob', 3, false)
+  const bs = bob.createStream('alice', 3, true)
 
-  console.log('initial.alice:',alice.progress())
-  console.log('initial.bob  :',bob.progress())
+  console.log('initial.alice:', alice.progress())
+  console.log('initial.bob  :', bob.progress())
 
   as.pipe(bs).pipe(as)
 
-
-  alice.append({author: 'alice', sequence: 1, content: 'hello'}, function () {})
-  bob.append({author: 'bob', sequence: 1, content: 'hello'}, function () {})
+  alice.append({ author: 'alice', sequence: 1, content: 'hello' }, function () {})
+  bob.append({ author: 'bob', sequence: 1, content: 'hello' }, function () {})
 
   console.log(bob.store)
   console.log(alice.store)
 
-  console.log('final.alice:',alice.progress())
-  console.log('final.bob  :',bob.progress())
+  console.log('final.alice:', alice.progress())
+  console.log('final.bob  :', bob.progress())
 
   t.deepEqual(alice.store, bob.store)
   t.end()
-
 })
 
 test('a<->b,b', function (t) {
-
-  var alice = create('alice')
-  var bob = create('bob')
+  const alice = create('alice')
+  const bob = create('bob')
 
   alice.request('alice', true)
   alice.request('bob', true)
   bob.request('alice', true)
   bob.request('bob', true)
 
-  var as = alice.createStream('bob', 3, true)
-  var bs = bob.createStream('alice', 3, false)
+  const as = alice.createStream('bob', 3, true)
+  const bs = bob.createStream('alice', 3, false)
 
-  console.log('initial.alice:',alice.progress())
-  console.log('initial.bob  :',bob.progress())
+  console.log('initial.alice:', alice.progress())
+  console.log('initial.bob  :', bob.progress())
 
   as.pipe(bs).pipe(as)
 
-  alice.append({author: 'alice', sequence: 1, content: 'hello'}, function () {})
-  bob.append({author: 'bob', sequence: 1, content: 'hello'}, function () {})
+  alice.append({ author: 'alice', sequence: 1, content: 'hello' }, function () {})
+  bob.append({ author: 'bob', sequence: 1, content: 'hello' }, function () {})
 
   console.log(bob.store)
   console.log(alice.store)
 
-  console.log('final.alice:',alice.progress())
-  console.log('final.bob  :',bob.progress())
+  console.log('final.alice:', alice.progress())
+  console.log('final.bob  :', bob.progress())
 
   t.deepEqual(alice.store, bob.store)
 
   t.end()
 })
 
-
 test('a3<->b3<->c2', function (t) {
-
-  var alice = create('alice')
-  var bob = create('bob')
-  var charles = create('charles')
+  const alice = create('alice')
+  const bob = create('bob')
+  const charles = create('charles')
 
   alice.request('alice', true)
   alice.request('bob', true)
@@ -111,37 +103,35 @@ test('a3<->b3<->c2', function (t) {
   charles.request('alice', true)
   charles.request('bob', true)
 
-  var as3 = alice.createStream('bob', 3, true)
-  var bs3 = bob.createStream('alice', 3, false)
-  var bs2 = bob.createStream('charles', 3, false)
-  var cs2 = charles.createStream('bob', 3, true)
+  const as3 = alice.createStream('bob', 3, true)
+  const bs3 = bob.createStream('alice', 3, false)
+  const bs2 = bob.createStream('charles', 3, false)
+  const cs2 = charles.createStream('bob', 3, true)
 
-  console.log('initial.alice:',alice.progress())
-  console.log('initial.bob  :',bob.progress())
-  console.log('initial.charles  :',charles.progress())
+  console.log('initial.alice:', alice.progress())
+  console.log('initial.bob  :', bob.progress())
+  console.log('initial.charles  :', charles.progress())
 
   as3.pipe(bs3).pipe(as3)
   cs2.pipe(bs2).pipe(cs2)
 
-
-  alice.append({author: 'alice', sequence: 1, content: 'hello'}, function () {})
-  bob.append({author: 'bob', sequence: 1, content: 'hello'}, function () {})
+  alice.append({ author: 'alice', sequence: 1, content: 'hello' }, function () {})
+  bob.append({ author: 'bob', sequence: 1, content: 'hello' }, function () {})
 
   console.log(bob.store)
   console.log(alice.store)
 
-  console.log('final.alice:',alice.progress())
-  console.log('final.bob  :',bob.progress())
+  console.log('final.alice:', alice.progress())
+  console.log('final.bob  :', bob.progress())
 
   t.deepEqual(alice.store, bob.store)
   t.deepEqual(alice.store, charles.store)
   t.end()
-
 })
 
 test('a<-!>b', function (t) {
-  var alice = create('alice')
-  var bob = create('bob')
+  const alice = create('alice')
+  const bob = create('bob')
 
   alice.request('alice', true)
   alice.request('bob', true)
@@ -149,8 +139,8 @@ test('a<-!>b', function (t) {
   bob.request('alice', true)
   bob.request('bob', true)
 
-  var as = alice.createStream('bob', 3, false)
-  var bs = bob.createStream('alice', 3, true)
+  const as = alice.createStream('bob', 3, false)
+  const bs = bob.createStream('alice', 3, true)
 
   as.pipe(bs).pipe(as)
 
@@ -160,16 +150,16 @@ test('a<-!>b', function (t) {
 })
 
 test('a<->b...!', function (t) {
-  var alice = create('alice')
-  var bob = create('bob')
+  const alice = create('alice')
+  const bob = create('bob')
 
   alice.request('alice', true)
   alice.request('bob', true)
   bob.request('alice', true)
   bob.request('bob', true)
 
-  var as = alice.createStream('bob', 3, false)
-  var bs = bob.createStream('alice', 3, true)
+  const as = alice.createStream('bob', 3, false)
+  const bs = bob.createStream('alice', 3, true)
 
   as.pipe(bs).pipe(as)
 
@@ -184,8 +174,8 @@ test('a<->b...!', function (t) {
 })
 
 test('b<-!->a', function (t) {
-  var alice = create('alice')
-  var bob = create('bob')
+  const alice = create('alice')
+  const bob = create('bob')
 
   alice.request('alice', true)
   alice.request('bob', true)
@@ -193,8 +183,8 @@ test('b<-!->a', function (t) {
   bob.request('alice', true)
   bob.request('bob', true)
 
-  var as = alice.createStream('bob', 3, true)
-  var bs = bob.createStream('alice', 3, false)
+  const as = alice.createStream('bob', 3, true)
+  const bs = bob.createStream('alice', 3, false)
 
   as.pipe(bs).pipe(as)
 
@@ -202,13 +192,3 @@ test('b<-!->a', function (t) {
   t.equal(bs.ended, true)
   t.end()
 })
-
-
-
-
-
-
-
-
-
-

--- a/test/three.js
+++ b/test/three.js
@@ -1,33 +1,33 @@
 
-var createSimulator = require('./simulator')
-var options = require('./options')
+const createSimulator = require('./simulator')
+const options = require('./options')
 
-var test = require('tape')
+const test = require('tape')
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var charles = network['charles'] = tick.createPeer('charles')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const charles = network.charles = tick.createPeer('charles')
 
     alice.init({})
     bob.init({})
     charles.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
 
-    bob.append({author: 'bob', sequence: 1, content: {}})
-    bob.append({author: 'bob', sequence: 2, content: {}})
-    bob.append({author: 'bob', sequence: 3, content: {}})
+    bob.append({ author: 'bob', sequence: 1, content: {} })
+    bob.append({ author: 'bob', sequence: 2, content: {} })
+    bob.append({ author: 'bob', sequence: 3, content: {} })
 
-    charles.append({author: 'charles', sequence: 1, content: {}})
-    charles.append({author: 'charles', sequence: 2, content: {}})
-    charles.append({author: 'charles', sequence: 3, content: {}})
+    charles.append({ author: 'charles', sequence: 1, content: {} })
+    charles.append({ author: 'charles', sequence: 2, content: {} })
+    charles.append({ author: 'charles', sequence: 3, content: {} })
 
     alice.follow('alice')
     bob.follow('alice')
@@ -44,46 +44,38 @@ function createTest (seed, log) {
     alice.connect(bob)
     alice.connect(charles)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, alice.store, 'charles<->alice')
 
     alice.disconnect(charles)
 
-    alice.append({author: 'alice', sequence: 4, content: {}})
-    alice.append({author: 'alice', sequence: 5, content: {}})
+    alice.append({ author: 'alice', sequence: 4, content: {} })
+    alice.append({ author: 'alice', sequence: 5, content: {} })
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.notDeepEqual(charles.store, alice.store, 'alice<->bob')
 
     bob.connect(charles)
 
-    alice.append({author: 'alice', sequence: 6, content: {}})
+    alice.append({ author: 'alice', sequence: 6, content: {} })
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, alice.store, 'charles<->alice')
 
-    if(log) tick.log()
+    if (log) tick.log()
 
     t.end()
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed)) for(var i = 0; i < 100; i++) createTest(i)
+const seed = process.argv[2]
+if (isNaN(seed)) for (let i = 0; i < 100; i++) createTest(i)
 else createTest(+seed, true)
-
-
-
-
-
-
-
-

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,104 +1,100 @@
 
-var test = require('tape')
-var events = require('../events')(require('./options'))
+const test = require('tape')
+const events = require('../events')(require('./options'))
 
 test('switch peers if timeout exceeded', function (t) {
-  var state = {
+  let state = {
     id: 'alice',
-    clock: {bob: 5, charles: 6, dawn: 3},
+    clock: { bob: 5, charles: 6, dawn: 3 },
     retrive: [],
-    follows: {bob: true}, blocks: {},
-    timeout: 1000,
-    peers: {
-      bob: {
-        clock: {bob: 7},
-        notes: null,
-        replicating: { bob: {rx: true, tx: false, sent: -1 }},
-        ts: 3000
-      },
-      charles: {
-        clock: {bob: 10},
-        notes: null,
-        replicating: { bob: {rx: false, tx: false, sent: -1 }}
-      },
-      dawn: {
-        clock: {bob: 9},
-        notes: null,
-        replicating: { bob: {rx: false, tx: false, sent: -1 }}
-      }
-    }
-  }
-
-  state = events.timeout(state, {ts: 5000})
-
-  t.equal(state.peers.bob.replicating.bob.rx, false)
-  t.equal(state.peers.charles.replicating.bob.rx, true)
-
-  console.log(JSON.stringify(state, null, 2))
-
-  state = events.timeout(state, {ts: 10000})
-
-  t.equal(state.peers.charles.replicating.bob.rx, false)
-  t.equal(state.peers.dawn.replicating.bob.rx, true)
-
-  state = events.timeout(state, {ts: 15000})
-
-  t.equal(state.peers.dawn.replicating.bob.rx, false)
-  t.equal(state.peers.bob.replicating.bob.rx, true)
-
-  t.end()
-
-})
-
-test('if up to latest message by peer, swich if another peer claims newer', function (t) {
-  var state = {
-    id: 'alice',
-    clock: {bob: 7, charles: 6, dawn: 3},
-    retrive: [],
-    follows: {bob: true},
+    follows: { bob: true },
     blocks: {},
     timeout: 1000,
     peers: {
       bob: {
-        clock: {bob: 7},
+        clock: { bob: 7 },
         notes: null,
-        replicating: { bob: {rx: true, tx: false, sent: -1 }},
+        replicating: { bob: { rx: true, tx: false, sent: -1 } },
         ts: 3000
       },
       charles: {
-        clock: {bob: 10},
+        clock: { bob: 10 },
         notes: null,
-        replicating: { bob: {rx: false, tx: false, sent: -1 }}
+        replicating: { bob: { rx: false, tx: false, sent: -1 } }
       },
       dawn: {
-        clock: {bob: 9},
+        clock: { bob: 9 },
         notes: null,
-        replicating: { bob: {rx: false, tx: false, sent: -1 }}
+        replicating: { bob: { rx: false, tx: false, sent: -1 } }
       }
     }
   }
 
-  state = events.timeout(state, {ts: 5000})
+  state = events.timeout(state, { ts: 5000 })
 
   t.equal(state.peers.bob.replicating.bob.rx, false)
   t.equal(state.peers.charles.replicating.bob.rx, true)
 
+  console.log(JSON.stringify(state, null, 2))
 
-  state = events.timeout(state, {ts: 10000})
+  state = events.timeout(state, { ts: 10000 })
 
   t.equal(state.peers.charles.replicating.bob.rx, false)
   t.equal(state.peers.dawn.replicating.bob.rx, true)
 
-  state = events.timeout(state, {ts: 15000})
+  state = events.timeout(state, { ts: 15000 })
+
+  t.equal(state.peers.dawn.replicating.bob.rx, false)
+  t.equal(state.peers.bob.replicating.bob.rx, true)
+
+  t.end()
+})
+
+test('if up to latest message by peer, swich if another peer claims newer', function (t) {
+  let state = {
+    id: 'alice',
+    clock: { bob: 7, charles: 6, dawn: 3 },
+    retrive: [],
+    follows: { bob: true },
+    blocks: {},
+    timeout: 1000,
+    peers: {
+      bob: {
+        clock: { bob: 7 },
+        notes: null,
+        replicating: { bob: { rx: true, tx: false, sent: -1 } },
+        ts: 3000
+      },
+      charles: {
+        clock: { bob: 10 },
+        notes: null,
+        replicating: { bob: { rx: false, tx: false, sent: -1 } }
+      },
+      dawn: {
+        clock: { bob: 9 },
+        notes: null,
+        replicating: { bob: { rx: false, tx: false, sent: -1 } }
+      }
+    }
+  }
+
+  state = events.timeout(state, { ts: 5000 })
+
+  t.equal(state.peers.bob.replicating.bob.rx, false)
+  t.equal(state.peers.charles.replicating.bob.rx, true)
+
+  state = events.timeout(state, { ts: 10000 })
+
+  t.equal(state.peers.charles.replicating.bob.rx, false)
+  t.equal(state.peers.dawn.replicating.bob.rx, true)
+
+  state = events.timeout(state, { ts: 15000 })
 
   console.log(JSON.stringify(state, null, 2))
 
   t.equal(state.peers.dawn.replicating.bob.rx, false)
-//  t.equal(state.peers.charles.replicating.bob.rx, true)
+  //  t.equal(state.peers.charles.replicating.bob.rx, true)
   t.equal(state.peers.bob.replicating.bob.rx, true)
 
   t.end()
-
 })
-
-

--- a/test/two.js
+++ b/test/two.js
@@ -1,25 +1,25 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
 
-var test = require('tape')
+const test = require('tape')
 
 function createTest (seed, log) {
-  test('simple test with seed:'+seed, function (t) {
-    var tick = createSimulator(seed, log, options)
+  test('simple test with seed:' + seed, function (t) {
+    const tick = createSimulator(seed, log, options)
 
-    var network = {}
-    var alice = network['alice'] = tick.createPeer('alice')
-    var bob = network['bob'] = tick.createPeer('bob')
-    var charles = network['charles'] = tick.createPeer('charles')
+    const network = {}
+    const alice = network.alice = tick.createPeer('alice')
+    const bob = network.bob = tick.createPeer('bob')
+    const charles = network.charles = tick.createPeer('charles')
 
     alice.init({})
     bob.init({})
     charles.init({})
 
-    alice.append({author: 'alice', sequence: 1, content: {}})
-    alice.append({author: 'alice', sequence: 2, content: {}})
-    alice.append({author: 'alice', sequence: 3, content: {}})
+    alice.append({ author: 'alice', sequence: 1, content: {} })
+    alice.append({ author: 'alice', sequence: 2, content: {} })
+    alice.append({ author: 'alice', sequence: 3, content: {} })
 
     alice.follow('alice')
     bob.follow('alice')
@@ -28,65 +28,59 @@ function createTest (seed, log) {
     alice.connect(bob)
     alice.connect(charles)
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
-    //should have set up peer.replicatings to tx/rx alice
+    // should have set up peer.replicatings to tx/rx alice
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, alice.store, 'charles<->alice')
 
     alice.disconnect(charles)
 
-    alice.append({author: 'alice', sequence: 4, content: {}})
-    alice.append({author: 'alice', sequence: 5, content: {}})
+    alice.append({ author: 'alice', sequence: 4, content: {} })
+    alice.append({ author: 'alice', sequence: 5, content: {} })
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.notDeepEqual(charles.store, alice.store, 'alice<->bob')
 
     bob.connect(charles)
 
-    alice.append({author: 'alice', sequence: 6, content: {}})
+    alice.append({ author: 'alice', sequence: 6, content: {} })
 
-    while(tick(network)) ;
+    while (tick(network)) ;
 
     t.deepEqual(bob.store, alice.store, 'alice<->bob')
     t.deepEqual(charles.store, alice.store, 'charles<->alice')
 
-    var totals = tick.output.reduce(function (a, b) {
-      if(!a) a = [0,0,0]; a[0] ++; a[1 + (+b.msg)] ++
+    const totals = tick.output.reduce(function (a, b) {
+      if (!a) a = [0, 0, 0]; a[0]++; a[1 + (+b.msg)]++
       return a
     }, null)
 
-    t.equal(totals[1], 3*2, 'number of handshakes sent is connections*2')
-    t.equal(totals[2], 6*(3-1), 'number of msgs sent is msgs*(peers-1)')
+    t.equal(totals[1], 3 * 2, 'number of handshakes sent is connections*2')
+    t.equal(totals[2], 6 * (3 - 1), 'number of msgs sent is msgs*(peers-1)')
 
-    var prog = progress(alice.state)
+    const prog = progress(alice.state)
     t.equal(prog.current, prog.target)
-    var prog2 = progress(bob.state)
+    const prog2 = progress(bob.state)
     t.equal(prog2.current, prog2.target)
 
     console.log(alice.state.peers.bob)
 
-    if(log)
+    if (log) {
       console.log(
         tick.output.map(function (e) {
-          if(e.msg)
-            return e.from+'>'+e.to+':'+e.value.sequence
-          else
-            return e.from+'>'+e.to+':'+JSON.stringify(e.value)
+          if (e.msg) { return e.from + '>' + e.to + ':' + e.value.sequence } else { return e.from + '>' + e.to + ':' + JSON.stringify(e.value) }
         }).join('\n')
       )
+    }
 
     t.end()
   })
 }
 
-var seed = process.argv[2]
-if(isNaN(seed)) for(var i = 0; i < 100; i++) createTest(i)
+const seed = process.argv[2]
+if (isNaN(seed)) for (let i = 0; i < 100; i++) createTest(i)
 else createTest(+seed, true)
-
-
-
-

--- a/test/write-error.js
+++ b/test/write-error.js
@@ -1,7 +1,7 @@
-var createSimulator = require('./simulator')
-var options = require('./options')
-var progress = require('../progress')
-var test = require('tape')
+const createSimulator = require('./simulator')
+const options = require('./options')
+const progress = require('../progress')
+const test = require('tape')
 
 function count (output) {
   return output.reduce(function (a, b) {
@@ -11,33 +11,32 @@ function count (output) {
 
 function flatten (output) {
   return output.reduce(function (a, b) {
-    if(b.msg) return a
-    for(var k in b.value)
-      a[b.from][k] = options.getSequence(b.value[k])
+    if (b.msg) return a
+    for (const k in b.value) { a[b.from][k] = options.getSequence(b.value[k]) }
     return a
-  }, {alice: {}, bob: {}})
+  }, { alice: {}, bob: {} })
 }
 
 function isComplete (peer, name, t) {
-  var prog = progress(peer.state)
-  t.equal(prog.current, prog.target, name +' is complete')
+  const prog = progress(peer.state)
+  t.equal(prog.current, prog.target, name + ' is complete')
 }
 
 test('write error', function (t) {
-  var tick = createSimulator(0, true, options)
+  const tick = createSimulator(0, true, options)
 
-  var network = {}
-  var alice = network['alice'] = tick.createPeer('alice')
-  var bob = network['bob'] = tick.createPeer('bob')
+  const network = {}
+  const alice = network.alice = tick.createPeer('alice')
+  const bob = network.bob = tick.createPeer('bob')
 
   alice.init({})
   bob.init({})
 
-  alice.append({author: 'alice', sequence: 1, content: {}})
-  alice.append({author: 'alice', sequence: 2, content: {}})
-  alice.append({author: 'alice', sequence: 3, content: {}})
-  bob.append({author: 'bob', sequence: 1, content: {}})
-  bob.append({author: 'bob', sequence: 2, content: {}})
+  alice.append({ author: 'alice', sequence: 1, content: {} })
+  alice.append({ author: 'alice', sequence: 2, content: {} })
+  alice.append({ author: 'alice', sequence: 3, content: {} })
+  bob.append({ author: 'bob', sequence: 1, content: {} })
+  bob.append({ author: 'bob', sequence: 2, content: {} })
 
   alice.follow('bob')
   alice.follow('alice')
@@ -46,43 +45,43 @@ test('write error', function (t) {
 
   alice.connect(bob)
 
-  while(tick(network)) ;
+  while (tick(network)) ;
 
   const bobPeerState = alice.state.peers.bob
-  console.log("bob peer state", bobPeerState)
+  console.log('bob peer state', bobPeerState)
 
   alice.disconnect(bob)
 
-  //should have set up peer.replicatings to tx/rx alice
-  t.deepEqual(flatten(tick.output), {alice: {alice: 3, bob: 0}, bob: {alice: 0, bob: 2}})
+  // should have set up peer.replicatings to tx/rx alice
+  t.deepEqual(flatten(tick.output), { alice: { alice: 3, bob: 0 }, bob: { alice: 0, bob: 2 } })
   t.equal(count(tick.output), 2)
 
   t.deepEqual(bob.store, alice.store)
 
-  console.log("alice store", alice.store)
-  console.log("bob store", bob.store)
+  console.log('alice store', alice.store)
+  console.log('bob store', bob.store)
 
   isComplete(alice, 'alice', t)
   isComplete(bob, 'bob', t)
 
-  console.log("===========START OVER===========")
+  console.log('===========START OVER===========')
 
   // bob has a write error
 
-  bob.store.alice = bob.store.alice.slice(0,2)
+  bob.store.alice = bob.store.alice.slice(0, 2)
   bob.clocks.alice.alice = 2
   bob.state.clock.alice = 2
 
-  alice.append({author: 'alice', sequence: 4, content: {}})
+  alice.append({ author: 'alice', sequence: 4, content: {} })
 
   alice.connect(bob)
 
   // restore state
   alice.state.peers.bob.clock = { alice: 3, bob: 2 }
-  
-  while(tick(network)) ;
 
-  t.equal(bob.store.alice.length, 4, "bob has all alices messages")
+  while (tick(network)) ;
+
+  t.equal(bob.store.alice.length, 4, 'bob has all alices messages')
 
   t.end()
 })

--- a/v3.js
+++ b/v3.js
@@ -1,15 +1,15 @@
-exports.note = function note(seq, rx) {
+exports.note = function note (seq, rx) {
   return seq === -1 ? -1 : seq << 1 | !rx
 }
 
-exports.getSequence = function getSequence(seq) {
+exports.getSequence = function getSequence (seq) {
   return !Number.isInteger(seq) ? -1 : seq >> 1
 }
 
-exports.getReplicate = function getReplicate(seq) {
+exports.getReplicate = function getReplicate (seq) {
   return seq !== -1
 }
 
-exports.getReceive = function getReceive(seq) {
+exports.getReceive = function getReceive (seq) {
   return !(seq & 1)
 }


### PR DESCRIPTION
I don't mind too much what we use here, but keen to add some linting/ checkers/ formatters.

What I want:
- consistent generic formatting code style
- no dangling variables
- warnings about logically dangerous things (like unclear combinations of && , || )

Happy to use other tools to achieve same ends.
This PR only does the minimal auto-fixes. Some delicate manual fixes are left for a following PR (which would need closer review)

---

other changes I'd like to see:
- README fixups (examples don't reflect actual usage, I think there are some inaccuracies)
- rename `retrive` to `retrieve` (confusing typo - I presume - throughout the code)
- delete `test/all.js` - it does nothing
- add tap-arc or similar
- extract a common "testbot" for easier maintenance into a single file (later) 